### PR TITLE
Add a small OMERO server-side microservice with RESTful API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+This is a simple microservice that shows how a web endpoint can be provided
+for querying role IDs from an OMERO database.
+Put your OMERO server configuration into etc/omero.properties then run:
+
+java -jar target/omero-ms-zarr-0.1.0-SNAPSHOT-jar-with-dependencies.jar etc/omero.properties
+
+and try
+
+src/scripts/post.py

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+        http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.openmicroscopy</groupId>
+  <artifactId>omero-ms-zarr</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+
+  <name>omero-ms-zarr</name>
+  <description>Microservice for publishing OMERO images in Zarr format</description>
+
+  <organization>
+    <name>Open Microscopy Environment</name>
+    <url>https://www.openmicroscopy.org/</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <id>openmicroscopy.org</id>
+      <name>The OME Team</name>
+      <email>ome-devel@lists.openmicroscopy.org.uk</email>
+      <url>https://www.openmicroscopy.org/</url>
+      <organization>Open Microscopy Environment</organization>
+      <organizationUrl>https://www.openmicroscopy.org/</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+	<groupId>org.openmicroscopy</groupId>
+	<artifactId>omero-server</artifactId>
+	<version>5.5.6</version>
+        <exclusions>
+          <exclusion>
+            <groupId>hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+	<artifactId>guava</artifactId>
+	<version>27.1-jre</version>
+      </dependency>
+      <dependency>
+	<groupId>org.slf4j</groupId>
+	<artifactId>slf4j-api</artifactId>
+	<version>1.7.25</version>
+      </dependency>
+      <dependency>
+	<groupId>io.vertx</groupId>
+	<artifactId>vertx-core</artifactId>
+	<version>3.9.0</version>
+      </dependency>
+      <dependency>
+	<groupId>io.vertx</groupId>
+	<artifactId>vertx-web</artifactId>
+	<version>3.9.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openmicroscopy</groupId>
+      <artifactId>omero-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>ome.maven</id>
+      <name>OME Maven Artifactory</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/maven</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.openmicroscopy.ms.zarr.ZarrDataService</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.openmicroscopy.ms.zarr.ZarrDataService</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.openmicroscopy.ms.zarr.ZarrDataService</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <show>private</show>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForId.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForId.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+/**
+ * Provide system role IDs from JDBC to HTTP endpoint.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class RequestHandlerForId implements Handler<RoutingContext> {
+
+    private final Connection connection;
+
+    public RequestHandlerForId(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * Add this as both GET and POST handler for the given path.
+     * @param router the router for which this can handle requests
+     * @param path the path on which those requests come
+     */
+    public void handleFor(Router router, String path) {
+        router.get(path).handler(this);
+        router.post(path).handler(BodyHandler.create()).handler(this);
+    }
+
+    /**
+     * Construct a HTTP failure response.
+     * @param response the HTTP response that is to bear the failure
+     * @param code the HTTP response code
+     * @param message a message that describes the failure
+     */
+    private static void fail(HttpServerResponse response, int code, String message) {
+        response.setStatusCode(code);
+        response.setStatusMessage(message);
+        response.end();
+    }
+
+    /**
+     * Handle incoming requests that query OMERO system user and group IDs.
+     * @param context the routing context
+     */
+    @Override
+    public void handle(RoutingContext context) {
+        final HttpServerRequest request = context.request();
+        final HttpServerResponse response = request.response();
+        /* get role and type from query */
+        final String role, type;
+        switch (request.method()) {
+            case GET:
+                role = request.getParam("role");
+                type = request.getParam("type");
+                break;
+            case POST:
+                final JsonObject body = context.getBodyAsJson();
+                role = body.getString("role");
+                type = body.getString("type");
+                break;
+            default:
+                fail(response, 404, "unknown path for this method");
+                return;
+        }
+        /* validate query parameters */
+        if (role == null || type == null) {
+            fail(response, 400, "must provide both role and type parameters");
+            return;
+        }
+        for (final char character : (role + type).toCharArray()) {
+            if (!Character.isLetter(character)) {
+                fail(response, 400, "role and type must each be a single word");
+                return;
+            }
+        }
+        /* query ID from database */
+        final long id;
+        try (final Statement statement = connection.createStatement()) {
+            final ResultSet rows = statement.executeQuery("SELECT " + role + "_" + type + "_id FROM _roles");
+            if (rows.next()) {
+                id = rows.getLong(1);
+            } else {
+                fail(response, 500, "database query returned no data");
+                return;
+            }
+        } catch (SQLException sqle) {
+            fail(response, 500, "database query failed");
+            return;
+        }
+        /* return ID in JSON by HTTP */
+        final JsonObject responseJson = new JsonObject(ImmutableMap.of("id", id));
+        final String responseText = responseJson.toString();
+        response.putHeader("Content-Type", "application/json; charset=utf-8");
+        response.putHeader("Content-Length", Integer.toString(responseText.length()));
+        response.end(responseText);
+    }
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Vertx;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Microservice providing JDBC queries over a HTTP endpoint.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class ZarrDataService {
+
+    /**
+     * Obtains the OMERO data source configured from Java system properties (may be loaded from configuration files named in
+     * arguments) then starts a verticle that listens on HTTP for queries, checks the database then responds in JSON.
+     * @param argv filename(s) from which to read configuration beyond current Java system properties
+     * @throws IOException if the configuration could not be loaded
+     */
+    public static void main(String[] argv) throws IOException {
+        /* set system properties from named configuration files */
+        final Properties propertiesSystem = System.getProperties();
+        for (final String filename : argv) {
+            final Properties propertiesNew = new Properties();
+            try (final InputStream filestream = new FileInputStream(filename)) {
+                propertiesNew.load(filestream);
+            }
+            propertiesSystem.putAll(propertiesNew);
+        }
+        /* start up OMERO.server's data layer and obtain its dataSource bean for JDBC */
+        final AbstractApplicationContext zarrContext = new ClassPathXmlApplicationContext("zarr-context.xml");
+        final ApplicationContext omeroContext = zarrContext.getBean("zarr.data", ApplicationContext.class);
+        final DataSource dataSource = omeroContext.getBean("nonXaDataSource", DataSource.class);
+        /* deploy the verticle which uses OMERO's data source */
+        final Vertx vertx = Vertx.vertx();
+        vertx.deployVerticle(new ZarrDataVerticle(dataSource), (AsyncResult<String> result) -> {
+            zarrContext.close();
+        });
+    }
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataVerticle.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataVerticle.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Router;
+
+/**
+ * Set up HTTP endpoint with JDBC connection.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class ZarrDataVerticle implements Verticle {
+
+    private final DataSource dataSource;
+
+    private Vertx vertx;
+    private Context context;  // unused
+
+    private Connection connection;
+    private HttpServer server;
+
+    public ZarrDataVerticle(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Vertx getVertx() {
+        return vertx;
+    }
+
+    @Override
+    public void init(Vertx vertx, Context context) {
+        this.vertx = vertx;
+        this.context = context;
+    }
+
+    /**
+     * Starts the verticle: gets a JDBC connection and listens on HTTP port 8080.
+     * The verticle includes no logic for retrying a lost JDBC connection
+     * @param future for reporting the outcome
+     * @throws SQLException if a JDBC connection could not be obtained
+     */
+    @Override
+    public void start(Future<Void> future) throws SQLException {
+        /* obtain JDBC connection */
+        connection = dataSource.getConnection();
+        /* listen for queries over HTTP */
+        final Router router = Router.router(vertx);
+        server = vertx.createHttpServer(new HttpServerOptions().setPort(8080));
+        server.requestHandler(router::accept);
+        new RequestHandlerForId(connection).handleFor(router, "/id");
+        server.listen();  // does not yet handle failure
+        future.complete();
+    }
+
+    /**
+     * Closes the JDBC connection and the HTTP server.
+     * @param future for reporting the outcome
+     * @throws SQLException if the JDBC connection could not be closed
+     */
+    @Override
+    public void stop(Future<Void> future) throws SQLException {
+        connection.close();
+        server.close();
+        future.complete();
+    }
+}

--- a/src/main/resources/zarr-context.xml
+++ b/src/main/resources/zarr-context.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
+  "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+  <bean id="zarr.data" class="ome.system.OmeroContext">
+    <constructor-arg>
+      <list>
+        <value>classpath:ome/config.xml</value>
+        <value>classpath:ome/services/datalayer.xml</value>
+      </list>
+    </constructor-arg>
+  </bean>
+</beans>

--- a/src/scripts/post.py
+++ b/src/scripts/post.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018-2020 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# POST JSON requests to Zarr microservice
+# author: m.t.b.carroll@dundee.ac.uk
+
+import requests
+
+queries = [
+    {
+        'role': 'guest',
+        'type': 'user'
+    }, {
+        'role': 'system',
+        'type': 'group'
+    }
+]
+
+for query in queries:
+    response = requests.post('http://localhost:8080/id', json=query)
+
+    if response.status_code != 200:
+        print('{}: {}'.format(response.status_code, response.reason))
+    else:
+        print(response.json()['id'])
+        print('elapsed time: {}\n'.format(response.elapsed))


### PR DESCRIPTION
This PR bears a simplified https://gitlab.com/openmicroscopy/incubator/omero-ms-mapr-jdbc showing how to use OMERO context to obtain user/group IDs and offer them from a JSON API over HTTP. Next steps (unordered) are plausibly:

* Bring up enough context for `PixelsService` to be used to instantiate pixel buffers.
* Based on https://github.com/jhamman/xpublish endpoints offer a Zarr-based view of pixel buffers.
  * Including min-max from StatsInfo could assist napari.
* Drop the example ID-providing endpoint.
* Translate the `pom.xml` to a `build.gradle`.