### PR TITLE
Add python script to convert IDR image to Zarr

### DIFF
--- a/examples/idr2zarr/idr-image2zarr.py
+++ b/examples/idr2zarr/idr-image2zarr.py
@@ -1,0 +1,73 @@
+from glob import glob
+import itertools
+import numpy as np
+import os
+import re
+import sys
+import zarr
+from omero.gateway import BlitzGateway
+
+if len(sys.argv) != 2:
+    print('IDR image ID required')
+    sys.exit(2)
+
+iid = int(sys.argv[1])
+
+# Download all image planes individually as npy arrays
+# so that if there's an error we can continue
+print('Downloading IDR image ID: {}'.format(iid))
+conn = BlitzGateway(
+    host='idr.openmicroscopy.org', username='public', passwd='public',
+    secure=True)
+assert conn.connect()
+im = conn.getObject('Image', iid)
+
+shape = [getattr(im, 'getSize' + d)() for d in 'XYZCT']
+print(shape)
+
+px = im.getPrimaryPixels()
+zcts = itertools.product(*map(range, shape[2:]))
+os.makedirs(str(iid), mode=511, exist_ok=True)
+
+for (z, c, t) in zcts:
+    filename = '{}/{:03d}-{:03d}-{:03d}.npy'.format(iid, z, c, t)
+    if os.path.exists(filename):
+        print('{} exists, skipping'.format(filename))
+        continue
+    print('Saving {}'.format(filename))
+    p = px.getPlane(z, c, t)
+    np.save(filename, p)
+
+conn.close()
+
+
+# Now convert the downloaded planes
+srcglob = '{}/*.npy'.format(iid)
+output = '{}.zarr'.format(iid)
+print('Converting {} to {}'.format(srcglob, output))
+files = sorted(glob(srcglob))
+lastd = re.match(
+    r'(?P<iid>\d+)/(?P<z>\d+)-(?P<c>\d+)-(?P<t>\d+).npy', files[-1]
+    ).groupdict()
+for k, v in lastd.items():
+    lastd[k] = int(v)
+
+first = np.load(files[0])
+chunksize = (first.shape[0], first.shape[0], 5, 1, 5)
+
+za = zarr.open(
+    output,
+    mode='w',
+    shape=(first.shape[0], first.shape[0],
+           lastd['z'] + 1, lastd['c'] + 1, lastd['t'] + 1),
+    chunks=chunksize,
+    dtype=first.dtype)
+
+for z in range(lastd['z'] + 1):
+    print(z)
+    for c in range(lastd['c'] + 1):
+        for t in range(lastd['t'] + 1):
+            f = '{}/{:03d}-{:03d}-{:03d}.npy'.format(iid, z, c, t)
+            za[:, :, z, c, t] = np.load(f)
+
+print(za)

--- a/examples/idr2zarr/idr-image2zarr.py
+++ b/examples/idr2zarr/idr-image2zarr.py
@@ -7,6 +7,12 @@ import sys
 import zarr
 from omero.gateway import BlitzGateway
 
+
+def get_chunk_size(x, y, z, c, t):
+    # return (x, y, 5, 1, 5)
+    return (x, y, 1, 1, 1)
+
+
 if len(sys.argv) != 2:
     print('IDR image ID required')
     sys.exit(2)
@@ -53,12 +59,13 @@ for k, v in lastd.items():
     lastd[k] = int(v)
 
 first = np.load(files[0])
-chunksize = (first.shape[0], first.shape[0], 5, 1, 5)
+chunksize = get_chunk_size(first.shape[0], first.shape[1],
+                           lastd['z'] + 1, lastd['c'] + 1, lastd['t'] + 1)
 
 za = zarr.open(
     output,
     mode='w',
-    shape=(first.shape[0], first.shape[0],
+    shape=(first.shape[0], first.shape[1],
            lastd['z'] + 1, lastd['c'] + 1, lastd['t'] + 1),
     chunks=chunksize,
     dtype=first.dtype)


### PR DESCRIPTION
```
$ python idr-image2zarr.py 4995041

Downloading IDR image ID: 4995041
[1488, 1488, 9, 3, 1]
Saving 4995041/000-000-000.npy
Saving 4995041/000-001-000.npy
Saving 4995041/000-002-000.npy
Saving 4995041/001-000-000.npy
Saving 4995041/001-001-000.npy
Saving 4995041/001-002-000.npy
Saving 4995041/002-000-000.npy
Saving 4995041/002-001-000.npy
Saving 4995041/002-002-000.npy
Saving 4995041/003-000-000.npy
Saving 4995041/003-001-000.npy
Saving 4995041/003-002-000.npy
Saving 4995041/004-000-000.npy
Saving 4995041/004-001-000.npy
Saving 4995041/004-002-000.npy
Saving 4995041/005-000-000.npy
Saving 4995041/005-001-000.npy
Saving 4995041/005-002-000.npy
Saving 4995041/006-000-000.npy
Saving 4995041/006-001-000.npy
Saving 4995041/006-002-000.npy
Saving 4995041/007-000-000.npy
Saving 4995041/007-001-000.npy
Saving 4995041/007-002-000.npy
Saving 4995041/008-000-000.npy
Saving 4995041/008-001-000.npy
Saving 4995041/008-002-000.npy
Converting 4995041/*.npy to 4995041.zarr
0
1
2
3
4
5
6
7
8
<zarr.core.Array (1488, 1488, 9, 3, 1) uint16>
```