### PR TITLE
Add omero_to_zarr.py

### DIFF
--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -1,0 +1,131 @@
+
+import argparse
+import sys
+import os
+
+import omero.clients
+from omero.cli import cli_login
+from omero.gateway import BlitzGateway
+
+import xarray as xr
+import numpy
+import zarr
+
+# Uses CLI login to load Image from OMERO and save as zarr:
+
+# $ python omero_to_zarr.py 123
+# will create 123.zarr
+
+# $ python omero_to_zarr.py 123 --xarray
+# creates 123_xarray.zarr
+
+
+def get_data(img, c=0):
+    """
+    Get n-dimensional numpy array of pixel data for the OMERO image.
+
+    :param  img:        omero.gateway.ImageWrapper
+    :c      int:        Channel index
+    """
+    sz = img.getSizeZ()
+    st = img.getSizeT()
+    # get all planes we need
+    zct_list = [(z, c, t) for t in range(st) for z in range(sz)]
+    pixels = img.getPrimaryPixels()
+    planes = []
+    for p in pixels.getPlanes(zct_list):
+        planes.append(p)
+    # If we don't have multi-Z AND multi-T, return a 1D array of 2D planes
+    if sz == 1 or st == 1:
+        return numpy.array(planes)
+    # arrange plane list into 2D numpy array of planes
+    z_stacks = []
+    for t in range(st):
+        z_stacks.append(numpy.array(planes[t * sz: (t + 1) * sz]))
+    return numpy.array(z_stacks)
+
+
+def image_to_xarray(image):
+    
+    name = '%s_xarray.zarr' % image.id
+    if os.path.exists(name):
+        # If exists, ds.to_zarr(name) will fail with: ValueError: path '' contains a group
+        print("%s already exists!" % name)
+        return
+    xr_data = {}
+
+    # we create an xarrary.Dataset: each key is channel index (as string)
+    for idx in range(image.getSizeC()):
+        print(idx)
+        # get e.g. 3D np array for each channel
+        data = get_data(image, c=idx)
+        print(data.shape)
+        xr_data[str(idx)] = (('z', 'y', 'x'), data)
+
+    ds = xr.Dataset(xr_data)
+    ds.to_zarr(name)
+
+
+def image_to_zarr(image):
+
+    size_c = image.getSizeC()
+    size_z = image.getSizeZ()
+    size_x = image.getSizeX()
+    size_y = image.getSizeY()
+    size_t = image.getSizeT()
+
+    name = '%s.zarr' % image.id
+    za = None
+    pixels = image.getPrimaryPixels()
+
+    zct_list = []
+    for z in range(size_z):
+        for c in range(size_c):
+            for t in range(size_t):
+                zct_list.append( (z,c,t) )
+
+    def planeGen():
+        planes = pixels.getPlanes(zct_list)
+        for p in planes:
+            yield p
+
+    planes = planeGen()
+
+    for z in range(size_z):
+        print(z)
+        for c in range(size_c):
+            for t in range(size_t):
+                plane = next(planes)
+                if za is None:
+                    za = zarr.open(
+                        name,
+                        mode='w',
+                        shape=(size_c, size_z, size_t, size_y, size_x),
+                        chunks=(1, 1, 1, size_y, size_x),
+                        dtype=plane.dtype
+                    )
+                print(plane.shape)
+                za[c, z, t, :, :] = plane
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('image_id', help='Image ID')
+    parser.add_argument(
+        "--xarray",
+        action="store_true",
+        help=("Save as xarray, suitable for xpublish")
+    )
+    args = parser.parse_args(argv)
+
+    with cli_login() as cli:
+        conn = BlitzGateway(client_obj=cli._client)
+        image = conn.getObject('Image', args.image_id)
+        if args.xarray:
+            image_to_xarray(image)
+        else:
+            image_to_zarr(image)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -57,9 +57,10 @@ def image_to_zarr(image):
                     plane = next(planes)
                     numpy.save(filename, plane)
                 if za is None:
-                    za = zarr.open(
-                        name,
-                        mode='w',
+                    store = zarr.NestedDirectoryStore(name)
+                    root = zarr.group(store=store, overwrite=True)
+                    za = root.create(
+                        '0',
                         shape=(size_t, size_c, size_z, size_y, size_x),
                         chunks=(1, 1, 1, size_y, size_x),
                         dtype=plane.dtype

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -7,7 +7,6 @@ import omero.clients
 from omero.cli import cli_login
 from omero.gateway import BlitzGateway
 
-import xarray as xr
 import numpy
 import zarr
 
@@ -15,61 +14,6 @@ import zarr
 
 # $ python omero_to_zarr.py 123
 # will create 123.zarr
-
-# $ python omero_to_zarr.py 123 --xarray
-# creates 123_xarray.zarr
-
-def get_planes(image):
-
-    size_c = image.getSizeC()
-    size_z = image.getSizeZ()
-    size_t = image.getSizeT()
-    pixels = image.getPrimaryPixels()
-
-    zct_list = []
-    for c in range(size_c):
-        for t in range(size_t):
-            for z in range(size_z):
-                zct_list.append( (z,c,t) )
-
-    def plane_gen():
-        planes = pixels.getPlanes(zct_list)
-        for p in planes:
-            yield p
-    
-    return plane_gen()
-
-def image_to_xarray(image):
-
-    size_c = image.getSizeC()
-    size_z = image.getSizeZ()
-    size_t = image.getSizeT()
-
-    name = '%s_xarray.zarr' % image.id
-    if os.path.exists(name):
-        # If exists, ds.to_zarr(name) will fail with: ValueError: path '' contains a group
-        print("%s already exists!" % name)
-        return
-    xr_data = {}
-
-    planes = get_planes(image)
-
-    xr_data = {}
-    for c in range(size_c):
-        t_stacks = []
-        for t in range(size_t):
-            z_stack = []
-            for z in range(size_z):
-                print('plane c:%s, t:%s, z:%s' % (c, t, z))
-                z_stack.append(next(planes))
-            t_stacks.append(numpy.array(z_stack))
-        t_stacks = numpy.array(t_stacks)
-        print('t_stacks', t_stacks.shape)
-        xr_data[str(c)] = (('t', 'z', 'y', 'x'), t_stacks)
-    ds = xr.Dataset(xr_data)
-    ds.to_zarr(name)
-    print("Created", name)
-
 
 def image_to_zarr(image):
 
@@ -79,15 +23,20 @@ def image_to_zarr(image):
     size_y = image.getSizeY()
     size_t = image.getSizeT()
 
+    # dir for caching .npy planes
+    os.makedirs(str(image.id), mode=511, exist_ok=True)
     name = '%s.zarr' % image.id
     za = None
     pixels = image.getPrimaryPixels()
 
     zct_list = []
-    for z in range(size_z):
+    for t in range(size_t):
         for c in range(size_c):
-            for t in range(size_t):
-                zct_list.append( (z,c,t) )
+            for z in range(size_z):
+                # We only want to load from server if not cached locally
+                filename = '{}/{:03d}-{:03d}-{:03d}.npy'.format(image.id, z, c, t)
+                if not os.path.exists(filename):
+                    zct_list.append( (z,c,t) )
 
     def planeGen():
         planes = pixels.getPlanes(zct_list)
@@ -96,41 +45,39 @@ def image_to_zarr(image):
 
     planes = planeGen()
 
-    for z in range(size_z):
-        print(z)
+    for t in range(size_t):
         for c in range(size_c):
-            for t in range(size_t):
-                plane = next(planes)
+            for z in range(size_z):
+                filename = '{}/{:03d}-{:03d}-{:03d}.npy'.format(image.id, z, c, t)
+                if os.path.exists(filename):
+                    print('plane (from disk) c:%s, t:%s, z:%s' % (c, t, z))
+                    plane = numpy.load(filename)
+                else:
+                    print('loading plane c:%s, t:%s, z:%s' % (c, t, z))
+                    plane = next(planes)
+                    numpy.save(filename, plane)
                 if za is None:
                     za = zarr.open(
                         name,
                         mode='w',
-                        shape=(size_c, size_z, size_t, size_y, size_x),
+                        shape=(size_t, size_c, size_z, size_y, size_x),
                         chunks=(1, 1, 1, size_y, size_x),
                         dtype=plane.dtype
                     )
-                print(plane.shape)
-                za[c, z, t, :, :] = plane
+                print('t, c, z,' , t, c, z, plane.shape)
+                za[t, c, z, :, :] = plane
     print("Created", name)
 
 
 def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument('image_id', help='Image ID')
-    parser.add_argument(
-        "--xarray",
-        action="store_true",
-        help=("Save as xarray, suitable for xpublish")
-    )
     args = parser.parse_args(argv)
 
     with cli_login() as cli:
         conn = BlitzGateway(client_obj=cli._client)
         image = conn.getObject('Image', args.image_id)
-        if args.xarray:
-            image_to_xarray(image)
-        else:
-            image_to_zarr(image)
+        image_to_zarr(image)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -57,7 +57,7 @@ def image_to_zarr(image):
                     plane = next(planes)
                     numpy.save(filename, plane)
                 if za is None:
-                    store = zarr.NestedDirectoryStore(name)
+                    store = zarr.DirectoryStore(name)
                     root = zarr.group(store=store, overwrite=True)
                     za = root.create(
                         '0',

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -28,8 +28,8 @@ def get_planes(image):
 
     zct_list = []
     for c in range(size_c):
-        for z in range(size_z):
-            for t in range(size_t):
+        for t in range(size_t):
+            for z in range(size_z):
                 zct_list.append( (z,c,t) )
 
     def plane_gen():
@@ -56,15 +56,16 @@ def image_to_xarray(image):
 
     xr_data = {}
     for c in range(size_c):
-        z_stack = []
-        for z in range(size_z):
-            t_stack = []
-            for t in range(size_t):
-                t_stack.append(next(planes))
-            z_stack.append(numpy.array(t_stack))
-        z_stack = numpy.array(z_stack)
-        print('z_stack', z_stack.shape)
-        xr_data[str(c)] = (('z', 't', 'y', 'x'), z_stack)
+        t_stacks = []
+        for t in range(size_t):
+            z_stack = []
+            for z in range(size_z):
+                print('plane c:%s, t:%s, z:%s' % (c, t, z))
+                z_stack.append(next(planes))
+            t_stacks.append(numpy.array(z_stack))
+        t_stacks = numpy.array(t_stacks)
+        print('t_stacks', t_stacks.shape)
+        xr_data[str(c)] = (('t', 'z', 'y', 'x'), t_stacks)
     ds = xr.Dataset(xr_data)
     ds.to_zarr(name)
     print("Created", name)


### PR DESCRIPTION
Creates zarr file which can be opened with napari.

## Usage:
Creates 'plain' Zarr (no groups)

```
# uses omero CLI login - will create 123.zarr
$ python omero_to_zarr 123
```

This is based on @manics example, but uses a different `shape`,
based on XYZCT dimension order, shape is:
```
shape=(size_t, size_c, size_z, size_y, size_x),
```

Can open with ```napari 0.2.12``` with:

```
im = da.from_zarr('./123.zarr')
with napari.gui_qt():
    viewer = napari.view_image(
        im,
        # Required, otherwise all data is loaded to find min/max
        contrast_limits=(min, max)
```

## Workflow to upload files to s3

```
$ python omero_to_zarr.py 9767678
# login as public user to idr

$ rsync -rvP --progress 9767678.zarr 10.0.48.3:/uod/idr/objectstore/minio/idr/zarr/
```

IDR Images I've done this for:

 - [9767678](http://idr.openmicroscopy.org/webclient/?show=image-9767678): idr0056, uint16, X: 660, Y: 501, Z: 1, T: 1, C: 3, total = 1.2 MB
 - [6001240](http://idr.openmicroscopy.org/webclient/?show=image-6001240): idr0062, uint16, X: 271, Y: 275, Z: 236, T: 1, C: 2, total = 35.2 MB
 - [179693](http://idr.openmicroscopy.org/webclient/?show=image-179693): idr0002, uint16, X: 1344, Y: 1024, Z: 1, T: 329, C: 2, --- took too long to download!
 - [5514379](http://idr.openmicroscopy.org/webclient/?show=image-5514379): idr0052. float, X: 256, Y: 256, Z:31, T: 40, C: 1, total = 24.1 MB. cell0005_R0001.companion.ome


If you install ```omero-napari``` with ``` pip install -e . ``` from PR https://gitlab.com/openmicroscopy/incubator/omero-napari/-/merge_requests/1

Then you can do this to view the image, loading data from s3:
```
$ omero napari view Image:6001240 --zarr
```