### PR TITLE
fetch-ms-zarr: use s3 layout (spec.md v0.1)

### DIFF
--- a/src/scripts/fetch-ms-zarr.py
+++ b/src/scripts/fetch-ms-zarr.py
@@ -32,12 +32,12 @@ parser.add_argument(
     "--dry-run", action="store_true",
     help="Don't actually download. Only check for existence")
 parser.add_argument(
-    "--endpoint_url",
+    "--endpoint-url",
     default="https://s3.embassy.ebi.ac.uk/",
     help=("Choose which service for download"
           " [%(default)s]"))
 parser.add_argument(
-    "--url_format",
+    "--url-format",
     default="{url}idr/zarr/v0.1/{image}.zarr/",
     help=("Format for the layout of URLs on the given service"
           " [%(default)s]"))

--- a/src/scripts/fetch-ms-zarr.py
+++ b/src/scripts/fetch-ms-zarr.py
@@ -27,19 +27,20 @@ import requests
 import sys
 import argparse
 
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = argparse.ArgumentParser()
 parser.add_argument(
     "--dry-run", action="store_true",
     help="Don't actually download. Only check for existence")
 parser.add_argument(
     "--endpoint_url",
     default="https://s3.embassy.ebi.ac.uk/",
-    help="Choose which service for download")
+    help=("Choose which service for download"
+          " [%(default)s]"))
 parser.add_argument(
     "--url_format",
     default="{url}idr/zarr/v0.1/{image}.zarr/",
-    help="Format for the layout of URLs on the given service")
+    help=("Format for the layout of URLs on the given service"
+          " [%(default)s]"))
 parser.add_argument("image", type=int)
 args = parser.parse_args()
 


### PR DESCRIPTION
This updates the fetch script to download files
from S3 (EBI & UoD). This is the layout that
the microservice likely will want to implement
over time. Up for discussion is certainly the
URL format (`{url}/idr/zarr/v0.1/{image}.zarr/`).
Note also that the multiscale metadata currently
differs.

cc: @mtbc