### PR TITLE
Close useless pixel buffer.

### DIFF
--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -118,6 +118,11 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
             final PixelBuffer buffer = pixelsService.getPixelBuffer(pixels, false);
             final int resolutions = buffer.getResolutionLevels();
             if (resolution >= resolutions) {
+                try {
+                    buffer.close();
+                } catch (IOException ioe) {
+                    /* probably closed anyway */
+                }
                 return null;
             }
             buffer.setResolutionLevel(resolutions - resolution - 1);


### PR DESCRIPTION
This PR corrects a missed opportunity to promptly close an instantiated pixel buffer.