### PR TITLE
have microservice provide multiscales value as an array

### DIFF
--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -43,6 +43,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -426,9 +427,11 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
             }
             datasets.add(dataset);
         }
-        final Map<String, Object> multiscales = new HashMap<>();
-        multiscales.put("version", "0.1");
-        multiscales.put("datasets", datasets);
+        final Map<String, Object> multiscale = new HashMap<>();
+        multiscale.put("version", "0.1");
+        multiscale.put("datasets", datasets);
+        final JsonArray multiscales = new JsonArray();
+        multiscales.add(multiscale);
         final Map<String, Object> result = new HashMap<>();
         result.put("multiscales", multiscales);
         respondWithJson(response, new JsonObject(result));


### PR DESCRIPTION
Fix multiscales metadata from microservice to match #17.

Should be able to continue using `fetch-ms-zarr.py` to download with,
`--endpoint_url http://localhost:8080/ --url_format '{url}image/{image}/'`