### PR TITLE
Add unit tests for microservice.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.4'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.3.3'
+    testImplementation 'io.vertx:vertx-codegen:3.9.0'  // workaround for JDK-8152174
     testImplementation 'software.amazon.awssdk:s3'
 }
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -63,10 +63,10 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
      * Cache open {@link PixelBuffer} instances given the likelihood of repeated calls.
      * @author m.t.b.carroll@dundee.ac.uk
      */
-    private class PixelBufferCache {
+    class PixelBufferCache {
 
         /* How many pixel buffers to keep open. Different resolutions count as different buffers. */
-        private static final int CAPACITY = 16;
+        static final int CAPACITY = 16;
 
         /* An open pixel buffer set to a specific image and resolution. */
         private class Entry {
@@ -158,7 +158,7 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
      * Contains the dimensionality of an image.
      * @author m.t.b.carroll@dundee.ac.uk
      */
-    private static class DataShape {
+    static class DataShape {
         final int xSize, ySize, cSize, zSize, tSize;
         final int byteWidth;
 
@@ -225,7 +225,7 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
     private static final Pattern PATTERN_ARRAY = Pattern.compile(REGEX_ARRAY);
     private static final Pattern PATTERN_CHUNK = Pattern.compile(REGEX_CHUNK);
 
-    private final PixelBufferCache cache = new PixelBufferCache();
+    final PixelBufferCache cache = new PixelBufferCache();
 
     private final PixelsService pixelsService;
     private final SessionFactory sessionFactory;

--- a/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import org.openmicroscopy.ms.zarr.RequestHandlerForImage.PixelBufferCache;
+
+import ome.io.nio.PixelBuffer;
+import ome.io.nio.PixelsService;
+import ome.model.core.Pixels;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
+/**
+ * Marks tests that require a minimum pixel buffer cache size, see {@link PixelBufferCache#CAPACITY}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledForSmallCacheCondition.class)
+@interface DisabledForSmallCache {
+    /**
+     * @return the minimum size of {@link PixelBufferCache#CAPACITY} required for the test
+     */
+    int minimumSize();
+}
+
+/**
+ * Implements {@link DisabledForSmallCache}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+class DisabledForSmallCacheCondition implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        final AnnotatedElement element = context.getElement().get();
+        final DisabledForSmallCache annotation = AnnotationUtils.findAnnotation(element, DisabledForSmallCache.class);
+        if (PixelBufferCache.CAPACITY >= annotation.minimumSize()) {
+            return ConditionEvaluationResult.enabled("cache is large enough");
+        } else {
+            return ConditionEvaluationResult.disabled("cache is not large enough");
+        }
+    }
+};
+
+/**
+ * Check that the {@link PixelBufferCache} behaves as intended and that it calls
+ * {@link PixelsService#getPixelBuffer(Pixels, boolean)} no more than expected.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class PixelBufferCacheTest {
+
+    /* How many resolution levels mock images should have. */
+    private static final int RESOLUTION_LEVELS = 3;
+
+    @Mock
+    private Query query;
+
+    @Mock
+    private Session sessionMock;
+
+    @Mock
+    private SessionFactory sessionFactoryMock;
+
+    @Mock
+    private PixelsService pixelsServiceMock;
+
+    private RequestHandlerForImage handler;
+
+    /**
+     * Set up the pixel buffer cache atop mock services.
+     */
+    @BeforeEach
+    public void mockSetup() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(query.uniqueResult()).thenReturn(new Pixels());
+        Mockito.when(sessionMock.createQuery(Mockito.anyString())).thenReturn(query);
+        Mockito.when(sessionFactoryMock.openSession()).thenReturn(sessionMock);
+        Mockito.when(pixelsServiceMock.getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false))).thenAnswer(
+                new Answer<PixelBuffer>() {
+            @Override
+            public PixelBuffer answer(InvocationOnMock invocation) {
+                /* Construct a new mock buffer each time to make them distinguishable */
+                final PixelBuffer buffer = Mockito.mock(PixelBuffer.class);
+                Mockito.when(buffer.getResolutionLevels()).thenReturn(RESOLUTION_LEVELS);
+                return buffer;
+            }});
+        handler = new RequestHandlerForImage(sessionFactoryMock, pixelsServiceMock, null);
+    }
+
+    /**
+     * Check that a pixel buffer is returned for valid resolutions and {@code null} for an invalid resolution.
+     */
+    @Test
+    public void testValidResolutions() {
+        int resolution;
+        for (resolution = 0; resolution < RESOLUTION_LEVELS; resolution++) {
+            final PixelBuffer buffer = handler.cache.getPixelBuffer(1, resolution);
+            Assertions.assertNotNull(buffer);
+            handler.cache.releasePixelBuffer(buffer);
+        }
+        final PixelBuffer buffer = handler.cache.getPixelBuffer(1, resolution);
+        Assertions.assertNull(buffer);
+        /* Check that the use of mocks was as expected. */
+        Mockito.verify(pixelsServiceMock,
+                Mockito.times(RESOLUTION_LEVELS + 1)).getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false));
+    }
+
+    /**
+     * For various images and resolutions check that their same corresponding buffer is returned on later cache queries.
+     */
+    @Test
+    @DisabledForSmallCache(minimumSize = 4)
+    public void testReuse() {
+        Assertions.assertTrue(RESOLUTION_LEVELS >= 2);
+        final Map<String, PixelBuffer> buffers = new HashMap<>();
+        final int repeats = 3;
+        for (int i = 0; i < repeats; i++) {
+            for (int image = 0; image < 2; image++) {
+                for (int resolution = 0; resolution < 2; resolution++) {
+                    final String key = String.format("%d:%d", image, resolution);
+                    final PixelBuffer expectedBuffer = buffers.get(key);
+                    final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, resolution);
+                    Assertions.assertNotNull(actualBuffer);
+                    if (expectedBuffer == null) {
+                        buffers.put(key, actualBuffer);
+                    } else {
+                        Assertions.assertEquals(expectedBuffer, actualBuffer);
+                    }
+                    handler.cache.releasePixelBuffer(actualBuffer);
+                }
+            }
+        }
+        Assertions.assertEquals(4, buffers.size());
+        /* Check that the use of mocks was as expected. */
+        Mockito.verify(pixelsServiceMock, Mockito.times(4)).getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false));
+    }
+
+    /**
+     * Check that the cache expires only those buffers that were fetched the longest time ago.
+     * @throws IOException unexpected
+     */
+    @Test
+    @DisabledForSmallCache(minimumSize = 8)  // expiryCount * 2
+    public void testExhaustion() throws IOException {
+        final int expiryCount = 4;
+        final int imageCount = PixelBufferCache.CAPACITY + expiryCount;
+        final int totalFetches = imageCount + expiryCount;
+        /* Fetch an image for every available buffer cache slot. */
+        final List<PixelBuffer> originalBuffers = new ArrayList<>();
+        for (int image = 0; image < PixelBufferCache.CAPACITY; image++) {
+            final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, 0);
+            Assertions.assertFalse(originalBuffers.contains(actualBuffer));
+            originalBuffers.add(actualBuffer);
+            handler.cache.releasePixelBuffer(actualBuffer);
+        }
+        /* Re-fetch half of the images, those should not be among those whose buffers expire subsequently. */
+        Assertions.assertEquals(PixelBufferCache.CAPACITY, new HashSet<>(originalBuffers).size());
+        for (int image = 0; image < PixelBufferCache.CAPACITY; image += 2) {
+            final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, 0);
+            final PixelBuffer expectedBuffer = originalBuffers.get(image);
+            Assertions.assertEquals(expectedBuffer, actualBuffer);
+            handler.cache.releasePixelBuffer(actualBuffer);
+        }
+        /* Figure which images' buffers should now expire. */
+        final Set<Integer> imagesExpired = new HashSet<>();
+        for (int image = 1; imagesExpired.size() < expiryCount; image += 2) {
+            imagesExpired.add(image);
+        }
+        /* Fetch some more images, that should expire some buffers from the other initial half. */
+        for (int image = PixelBufferCache.CAPACITY; image < imageCount; image++) {
+            final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, 0);
+            Assertions.assertFalse(originalBuffers.contains(actualBuffer));
+            originalBuffers.add(image, actualBuffer);
+            handler.cache.releasePixelBuffer(actualBuffer);
+        }
+        /* Check that for the non-expired buffers the original one is still returned. */
+        for (int image = 0; image < imageCount; image++) {
+            if (!imagesExpired.contains(image)) {
+                final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, 0);
+                final PixelBuffer expectedBuffer = originalBuffers.get(image);
+                Assertions.assertEquals(expectedBuffer, actualBuffer);
+                handler.cache.releasePixelBuffer(actualBuffer);
+            }
+        }
+        /* Check that for the expired buffers a new one is returned. */
+        for (final int image : imagesExpired) {
+            final PixelBuffer actualBuffer = handler.cache.getPixelBuffer(image, 0);
+            Assertions.assertFalse(originalBuffers.contains(actualBuffer));
+            handler.cache.releasePixelBuffer(actualBuffer);
+        }
+        /* Check that the use of mocks was as expected. */
+        Mockito.verify(pixelsServiceMock, Mockito.times(totalFetches)).getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false));
+        for (int image = 0; image < expiryCount * 2; image++) {
+            /* The even-numbered images' buffers were expired just above in replacing the odd-numbered's already-expired ones. */
+            final PixelBuffer buffer = originalBuffers.get(image);
+            Mockito.verify(buffer, Mockito.times(1)).close();
+        }
+        for (int image = expiryCount * 2; image < imageCount; image++) {
+            /* The images's buffers falling later in the above loops remain unexpired. */
+            final PixelBuffer buffer = originalBuffers.get(image);
+            Mockito.verify(buffer, Mockito.never()).close();
+        }
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
@@ -243,7 +243,7 @@ public class PixelBufferCacheTest {
             Mockito.verify(buffer, Mockito.times(1)).close();
         }
         for (int image = expiryCount * 2; image < imageCount; image++) {
-            /* The images's buffers falling later in the above loops remain unexpired. */
+            /* The images' buffers falling later in the above loops remain unexpired. */
             final PixelBuffer buffer = originalBuffers.get(image);
             Mockito.verify(buffer, Mockito.never()).close();
         }

--- a/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import org.openmicroscopy.ms.zarr.RequestHandlerForImage.DataShape;
+
+import ome.io.nio.PixelBuffer;
+
+import java.awt.Dimension;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.mockito.Mockito;
+
+/**
+ * Check that adjustments to tile sizes are made usefully and on a reasonable basis.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class TileSizeAdjustmentTest {
+
+    /**
+     * Create a {@link DataShape} for the given image plane dimensionality.
+     * @param x an image width
+     * @param y an image height
+     * @param bytes a byte width
+     * @return a new {@link DataShape}
+     */
+    public static DataShape getDataShape(int x, int y, int bytes) {
+        final PixelBuffer buffer = Mockito.mock(PixelBuffer.class);
+        final Dimension tileSize = new Dimension(256, 256);
+        Mockito.when(buffer.getSizeX()).thenReturn(x);
+        Mockito.when(buffer.getSizeY()).thenReturn(y);
+        Mockito.when(buffer.getSizeC()).thenReturn(3);
+        Mockito.when(buffer.getSizeZ()).thenReturn(1);
+        Mockito.when(buffer.getSizeT()).thenReturn(1);
+        Mockito.when(buffer.getTileSize()).thenReturn(tileSize);
+        Mockito.when(buffer.getByteWidth()).thenReturn(bytes);
+        return new DataShape(buffer);
+    }
+
+    /**
+     * Check that tile size adjustments are necessary and reasonable.
+     * @param shape a data shape
+     * @param targetChunkSize the chunk size to target
+     */
+    @ParameterizedTest
+    @MethodSource("provideDataShapes")
+    public void testAdjustTileSize(DataShape shape, int targetChunkSize) {
+        /* Determine the sizes, both before and after adjustment for comparison. */
+        final int beforeWidth = shape.xTile;
+        final int beforeHeight = shape.yTile;
+        final int beforeChunkSize = beforeWidth * beforeHeight * shape.byteWidth;
+        shape.adjustTileSize(targetChunkSize);
+        final int afterWidth = shape.xTile;
+        final int afterHeight = shape.yTile;
+        final int afterChunkSize = afterWidth * afterHeight * shape.byteWidth;
+        /* Tile dimensions larger than image dimensions should not be adjusted. */
+        if (beforeWidth >= shape.xSize) {
+            Assertions.assertEquals(beforeWidth, afterWidth);
+        }
+        if (beforeHeight >= shape.ySize) {
+            Assertions.assertEquals(beforeHeight, afterHeight);
+        }
+        /* If the tile size was already large enough then it should not be adjusted. */
+        if (beforeChunkSize >= targetChunkSize) {
+            Assertions.assertEquals(beforeWidth, afterWidth);
+            Assertions.assertEquals(beforeHeight, afterHeight);
+        }
+        /* If the adjusted tile size is not large enough then it should be at least the image size. */
+        if (afterChunkSize < targetChunkSize) {
+            if (beforeWidth > shape.xSize) {
+                Assertions.assertEquals(beforeWidth, afterWidth);
+            } else {
+                Assertions.assertEquals(shape.xSize, afterWidth);
+            }
+            if (beforeHeight > shape.ySize) {
+                Assertions.assertEquals(beforeHeight, afterHeight);
+            } else {
+                Assertions.assertEquals(shape.ySize, afterHeight);
+            }
+        }
+        /* Tile size changes must be increases and either to a multiple of the previous or to the image size. */
+        if (beforeWidth != afterWidth) {
+            Assertions.assertTrue(beforeWidth < afterWidth);
+            if (afterWidth != shape.xSize) {
+                Assertions.assertEquals(0, afterWidth % beforeWidth);
+            }
+        }
+        if (beforeHeight != afterHeight) {
+            Assertions.assertTrue(beforeHeight < afterHeight);
+            if (afterHeight != shape.ySize) {
+                Assertions.assertEquals(0, afterHeight % beforeHeight);
+            }
+        }
+    }
+
+    /**
+     * @return a set of various sizes for tile size adjustment to work on
+     */
+    private static Stream<Arguments> provideDataShapes() {
+        final Stream.Builder<Arguments> arguments = Stream.builder();
+        for (int bytes : new int[] {1, 2, 4}) {
+            for (final int chunkSide : new int[] {1000, 1024}) {
+                for (int xDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                    final int x = chunkSide * xDeciFactor / 10;
+                    for (int yDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                        final int y = chunkSide * yDeciFactor / 10;
+                        for (int wDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                            final int w = chunkSide * wDeciFactor / 10;
+                            for (int hDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                                final int h = chunkSide * hDeciFactor / 10;
+                                final DataShape shape = getDataShape(x, y, bytes);
+                                shape.xTile = w;
+                                shape.yTile = h;
+                                arguments.add(Arguments.of(shape, chunkSide * chunkSide));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return arguments.build();
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -109,9 +109,9 @@ public abstract class ZarrEndpointsTestBase {
      * @param query the query arguments for the microservice
      * @return the URI at which the answer is found
      */
-    private static String getUriPath(String... query) {
+    private static String getUriPath(Object... query) {
         final StringBuilder path = new StringBuilder(URI_PATH_PREFIX);
-        for (final String element : query) {
+        for (final Object element : query) {
             path.append('/');
             path.append(element);
         }
@@ -123,7 +123,7 @@ public abstract class ZarrEndpointsTestBase {
      * @param query arguments for the microservice query
      * @return the microservice's response as JSON
      */
-    protected JsonObject getResponseAsJson(String... query) {
+    protected JsonObject getResponseAsJson(Object... query) {
         Mockito.when(httpRequest.path()).thenReturn(getUriPath(query));
         handler.handle(context);
         final ArgumentCaptor<String> responseLengthCaptor = ArgumentCaptor.forClass(String.class);
@@ -143,7 +143,7 @@ public abstract class ZarrEndpointsTestBase {
      * @param query arguments for the microservice query
      * @return the microservice's response as bytes
      */
-    protected byte[] getResponseAsBytes(String... query) {
+    protected byte[] getResponseAsBytes(Object... query) {
         Mockito.when(httpRequest.path()).thenReturn(getUriPath(query));
         handler.handle(context);
         final ArgumentCaptor<String> responseLengthCaptor = ArgumentCaptor.forClass(String.class);
@@ -165,7 +165,7 @@ public abstract class ZarrEndpointsTestBase {
     protected Stream<Arguments> provideGroupDetails() throws IOException {
         mockSetup();
         final Stream.Builder<Arguments> details = Stream.builder();
-        Mockito.when(httpRequest.path()).thenReturn(getUriPath("0", ".zattrs"));
+        Mockito.when(httpRequest.path()).thenReturn(getUriPath(0, ".zattrs"));
         handler.handle(context);
         final JsonObject response = getResponseAsJson();
         final JsonArray multiscales = response.getJsonArray("multiscales");

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import org.openmicroscopy.ms.zarr.stub.PixelBufferFake;
+
+import ome.io.nio.PixelBuffer;
+import ome.io.nio.PixelsService;
+import ome.model.core.Pixels;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.provider.Arguments;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Base class providing mocks, fakes and utilities for testing microservice endpoints.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class ZarrEndpointsTestBase {
+
+    protected static final String MEDIA_TYPE_BINARY = "application/octet-stream";
+    protected static final String MEDIA_TYPE_JSON = "application/json; charset=utf-8";
+
+    protected static final String URI_PATH_PREFIX = "test";
+
+    @Mock
+    private Query query;
+
+    @Mock
+    private Session sessionMock;
+
+    @Mock
+    private SessionFactory sessionFactoryMock;
+
+    protected PixelBuffer pixelBuffer = new PixelBufferFake();
+
+    @Mock
+    private PixelsService pixelsServiceMock;
+
+    @Mock
+    private HttpServerRequest httpRequest;
+
+    @Mock
+    private HttpServerResponse httpResponse;
+
+    @Mock
+    private RoutingContext context;
+
+    private RequestHandlerForImage handler;
+
+    /**
+     * Set up the HTTP request handler atop mock services. Can be used to reset the mocks in between requests.
+     * @throws IOException unexpected
+     */
+    @BeforeEach
+    protected void mockSetup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(query.uniqueResult()).thenReturn(new Pixels());
+        Mockito.when(sessionMock.createQuery(Mockito.anyString())).thenReturn(query);
+        Mockito.when(sessionFactoryMock.openSession()).thenReturn(sessionMock);
+        Mockito.when(pixelsServiceMock.getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false))).thenReturn(pixelBuffer);
+        Mockito.when(httpRequest.method()).thenReturn(HttpMethod.GET);
+        Mockito.when(httpRequest.response()).thenReturn(httpResponse);
+        Mockito.when(context.request()).thenReturn(httpRequest);
+        handler = new RequestHandlerForImage(sessionFactoryMock, pixelsServiceMock, URI_PATH_PREFIX);
+    }
+
+    /**
+     * Construct an endpoint URI for the given query arguments.
+     * @param query the query arguments for the microservice
+     * @return the URI at which the answer is found
+     */
+    private static String getUriPath(String... query) {
+        final StringBuilder path = new StringBuilder(URI_PATH_PREFIX);
+        for (final String element : query) {
+            path.append('/');
+            path.append(element);
+        }
+        return path.toString();
+    }
+
+    /**
+     * Obtain a JSON object from the mock HTTP response.
+     * @param query arguments for the microservice query
+     * @return the microservice's response as JSON
+     */
+    protected JsonObject getResponseAsJson(String... query) {
+        Mockito.when(httpRequest.path()).thenReturn(getUriPath(query));
+        handler.handle(context);
+        final ArgumentCaptor<String> responseLengthCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> responseContentCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(httpResponse, Mockito.never()).setStatusCode(Mockito.anyInt());
+        Mockito.verify(httpResponse, Mockito.times(1)).putHeader(Mockito.eq("Content-Type"), Mockito.eq(MEDIA_TYPE_JSON));
+        Mockito.verify(httpResponse, Mockito.times(1)).putHeader(Mockito.eq("Content-Length"), responseLengthCaptor.capture());
+        Mockito.verify(httpResponse, Mockito.times(1)).end(responseContentCaptor.capture());
+        final int responseLength = Integer.parseInt(responseLengthCaptor.getValue());
+        final String responseContent = responseContentCaptor.getValue();
+        Assertions.assertEquals(responseLength, responseContent.length());
+        return new JsonObject(responseContent);
+    }
+
+    /**
+     * Obtain a byte array from the mock HTTP response.
+     * @param query arguments for the microservice query
+     * @return the microservice's response as bytes
+     */
+    protected byte[] getResponseAsBytes(String... query) {
+        Mockito.when(httpRequest.path()).thenReturn(getUriPath(query));
+        handler.handle(context);
+        final ArgumentCaptor<String> responseLengthCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Buffer> responseContentCaptor = ArgumentCaptor.forClass(Buffer.class);
+        Mockito.verify(httpResponse, Mockito.times(1)).putHeader(Mockito.eq("Content-Type"), Mockito.eq(MEDIA_TYPE_BINARY));
+        Mockito.verify(httpResponse, Mockito.times(1)).putHeader(Mockito.eq("Content-Length"), responseLengthCaptor.capture());
+        Mockito.verify(httpResponse, Mockito.times(1)).end(responseContentCaptor.capture());
+        final int responseLength = Integer.parseInt(responseLengthCaptor.getValue());
+        final Buffer responseContent = responseContentCaptor.getValue();
+        Assertions.assertEquals(responseLength, responseContent.length());
+        return responseContent.getBytes();
+    }
+
+    /**
+     * Provide arguments for tests iterating over the groups.
+     * @return the pixel buffer resolutions, URI path components and any scales for the testable groups
+     * @throws IOException unexpected
+     */
+    protected Stream<Arguments> provideGroupDetails() throws IOException {
+        mockSetup();
+        final Stream.Builder<Arguments> details = Stream.builder();
+        Mockito.when(httpRequest.path()).thenReturn(getUriPath("0", ".zattrs"));
+        handler.handle(context);
+        final JsonObject response = getResponseAsJson();
+        final JsonArray multiscales = response.getJsonArray("multiscales");
+        final JsonObject multiscale = multiscales.getJsonObject(0);
+        final JsonArray datasets = multiscale.getJsonArray("datasets");
+        int resolution = pixelBuffer.getResolutionLevels();
+        for (final Object element : datasets) {
+            final JsonObject dataset = (JsonObject) element;
+            details.add(Arguments.of(--resolution, dataset.getString("path"), dataset.getDouble("scale")));
+        }
+        return details.build();
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import java.awt.Dimension;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Check that the metadata served from the microservice endpoints are of the expected form.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class ZarrMetadataTest extends ZarrEndpointsTestBase {
+
+    /**
+     * Check that there are no unexpected keys among the JSON.
+     * @param json a JSON object
+     * @param keys the only permitted keys for the object, fails test if violated
+     */
+    private static void assertNoExtraKeys(JsonObject json, String... keys) {
+        final Set<String> actualKeys = json.fieldNames();
+        final Set<String> permittedKeys = ImmutableSet.copyOf(keys);
+        Assertions.assertTrue(Sets.difference(actualKeys, permittedKeys).isEmpty());
+    }
+
+    /**
+     * Check that the {@code .zgroup} from the microservice is as expected.
+     */
+    @Test
+    public void testZarrGroup() {
+        final JsonObject response = getResponseAsJson("0", ".zgroup");
+        assertNoExtraKeys(response, "zarr_format");
+        Assertions.assertEquals(2, response.getInteger("zarr_format"));
+    }
+
+    /**
+     * Check that the {@code .zattrs} from the microservice is as expected.
+     */
+    @Test
+    public void testZarrAttrs() {
+        final JsonObject response = getResponseAsJson("0", ".zattrs");
+        assertNoExtraKeys(response, "multiscales");
+        final JsonArray multiscales = response.getJsonArray("multiscales");
+        Assertions.assertEquals(1, multiscales.size());
+        final JsonObject multiscale = multiscales.getJsonObject(0);
+        assertNoExtraKeys(multiscale, "datasets", "version");
+        final JsonArray datasets = multiscale.getJsonArray("datasets");
+        Assertions.assertEquals(pixelBuffer.getResolutionLevels(), datasets.size());
+        boolean isScale1 = true;
+        final Set<String> paths = new HashSet<>();
+        for (final Object element : datasets) {
+            final JsonObject dataset = (JsonObject) element;
+            assertNoExtraKeys(dataset, "path", "scale");
+            final String path = dataset.getString("path");
+            Assertions.assertNotNull(path);
+            final Double scale = dataset.getDouble("scale");
+            if (isScale1) {
+                /* The first group listed is for the full-size image. */
+                Assertions.assertEquals(1, scale);
+                isScale1 = false;
+            }
+            paths.add(path);
+        }
+        Assertions.assertEquals(pixelBuffer.getResolutionLevels(), paths.size());
+        Assertions.assertEquals("0.1", multiscale.getString("version"));
+    }
+
+    /**
+     * Check that the {@code .zarray}s from the microservice are as expected.
+     * @param resolution the pixel buffer resolution corresponding to the currently tested group
+     * @param path the URI path component that selects the currently tested group
+     * @param scale any scale listed among the {@code .zattrs} for the the currently tested group, may be {@code null}
+     * @throws IOException unexpected
+     */
+    @ParameterizedTest
+    @MethodSource("provideGroupDetails")
+    public void testZarrArray(int resolution, String path, Double scale) throws IOException {
+        final JsonObject response = getResponseAsJson("0", path, ".zarray");
+        assertNoExtraKeys(response, "chunks", "compressor", "dtype", "fill_value", "filters", "order", "shape", "zarr_format");
+        Assertions.assertEquals(2, response.getInteger("zarr_format"));
+        Assertions.assertTrue(response.containsKey("fill_value"));
+        final JsonArray shape = response.getJsonArray("shape");
+        final JsonArray chunks = response.getJsonArray("chunks");
+        Assertions.assertEquals(5, shape.size());
+        Assertions.assertEquals(5, chunks.size());
+        final int shapeX = shape.getInteger(4);
+        final int shapeY = shape.getInteger(3);
+        final int shapeZ = shape.getInteger(2);
+        final int shapeC = shape.getInteger(1);
+        final int shapeT = shape.getInteger(0);
+        final int chunkX = chunks.getInteger(4);
+        final int chunkY = chunks.getInteger(3);
+        final int chunkZ = chunks.getInteger(2);
+        final int chunkC = chunks.getInteger(1);
+        final int chunkT = chunks.getInteger(0);
+        if (scale != null) {
+            pixelBuffer.setResolutionLevel(pixelBuffer.getResolutionLevels() - 1);
+            final long expectShapeX = Math.round(pixelBuffer.getSizeX() * scale);
+            final long expectShapeY = Math.round(pixelBuffer.getSizeY() * scale);
+            Assertions.assertEquals(expectShapeX, shapeX);
+            Assertions.assertEquals(expectShapeY, shapeY);
+        }
+        pixelBuffer.setResolutionLevel(resolution);
+        Assertions.assertEquals(pixelBuffer.getSizeX(), shapeX);
+        Assertions.assertEquals(pixelBuffer.getSizeY(), shapeY);
+        Assertions.assertEquals(pixelBuffer.getSizeZ(), shapeZ);
+        Assertions.assertEquals(pixelBuffer.getSizeC(), shapeC);
+        Assertions.assertEquals(pixelBuffer.getSizeT(), shapeT);
+        Assertions.assertEquals(1, chunkZ);
+        Assertions.assertEquals(1, chunkC);
+        Assertions.assertEquals(1, chunkT);
+        final Dimension tileSize = pixelBuffer.getTileSize();
+        if (chunkX != shapeX) {
+            Assertions.assertEquals(0, chunkX % tileSize.width);
+        }
+        if (chunkY != shapeY) {
+            Assertions.assertEquals(0, chunkY % tileSize.height);
+        }
+        Assertions.assertEquals(ByteOrder.LITTLE_ENDIAN, pixelBuffer.getTile(0, 0, 0, 0, 0, 1, 1).getOrder());
+        Assertions.assertEquals(false, pixelBuffer.isFloat());
+        Assertions.assertEquals(false, pixelBuffer.isSigned());
+        Assertions.assertEquals(2, pixelBuffer.getByteWidth());
+        Assertions.assertEquals("<u2", response.getString("dtype"));
+        Assertions.assertNotEquals(-1, "CF".indexOf(response.getString("order")));
+        Assertions.assertTrue(response.containsKey("compressor"));
+        final JsonObject compressor = response.getJsonObject("compressor");
+        if (compressor != null) {
+            Assertions.assertNotNull(compressor.getString("id"));
+        }
+        Assertions.assertTrue(response.containsKey("filters"));
+        final JsonArray filters = response.getJsonArray("filters");
+        if (filters != null) {
+            for (final Object element : filters) {
+                final JsonObject filter = (JsonObject) element;
+                Assertions.assertNotNull(filter.getString("id"));
+            }
+        }
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -58,7 +58,7 @@ public class ZarrMetadataTest extends ZarrEndpointsTestBase {
      */
     @Test
     public void testZarrGroup() {
-        final JsonObject response = getResponseAsJson("0", ".zgroup");
+        final JsonObject response = getResponseAsJson(0, ".zgroup");
         assertNoExtraKeys(response, "zarr_format");
         Assertions.assertEquals(2, response.getInteger("zarr_format"));
     }
@@ -68,7 +68,7 @@ public class ZarrMetadataTest extends ZarrEndpointsTestBase {
      */
     @Test
     public void testZarrAttrs() {
-        final JsonObject response = getResponseAsJson("0", ".zattrs");
+        final JsonObject response = getResponseAsJson(0, ".zattrs");
         assertNoExtraKeys(response, "multiscales");
         final JsonArray multiscales = response.getJsonArray("multiscales");
         Assertions.assertEquals(1, multiscales.size());
@@ -105,7 +105,7 @@ public class ZarrMetadataTest extends ZarrEndpointsTestBase {
     @ParameterizedTest
     @MethodSource("provideGroupDetails")
     public void testZarrArray(int resolution, String path, Double scale) throws IOException {
-        final JsonObject response = getResponseAsJson("0", path, ".zarray");
+        final JsonObject response = getResponseAsJson(0, path, ".zarray");
         assertNoExtraKeys(response, "chunks", "compressor", "dtype", "fill_value", "filters", "order", "shape", "zarr_format");
         Assertions.assertEquals(2, response.getInteger("zarr_format"));
         Assertions.assertTrue(response.containsKey("fill_value"));

--- a/src/test/java/org/openmicroscopy/ms/zarr/stub/PixelBufferFake.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/stub/PixelBufferFake.java
@@ -53,7 +53,7 @@ public class PixelBufferFake implements PixelBuffer {
         final byte[] pixels = new byte[w * h * 2];
         for (int xi = 0; xi < w; xi++) {
             for (int yi = 0; yi < h; yi++) {
-                final int wordOffset = yi * w + xi;
+                final int wordOffset = 2 * (w * yi + xi);
                 pixels[wordOffset] = (byte) xi;
                 pixels[wordOffset + 1] = (byte) yi;
             }

--- a/src/test/java/org/openmicroscopy/ms/zarr/stub/PixelBufferFake.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/stub/PixelBufferFake.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.stub;
+
+import ome.io.nio.PixelBuffer;
+import ome.util.PixelData;
+
+import java.awt.Dimension;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.Mockito;
+
+/**
+ * A fake {@link PixelBuffer} for providing basic dimensionality and tile methods. Represents a pyramidal tiled image.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class PixelBufferFake implements PixelBuffer {
+
+    static {
+        System.setProperty(PixelData.CONFIG_KEY, "true");
+    }
+
+    private final int resolutionLevels = 3;
+    private int resolutionLevel = resolutionLevels - 1;
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public PixelData getTile(Integer z, Integer c, Integer t, Integer x, Integer y, Integer w, Integer h) {
+        final byte[] pixels = new byte[w * h * 2];
+        for (int xi = 0; xi < w; xi++) {
+            for (int yi = 0; yi < h; yi++) {
+                final int wordOffset = yi * w + xi;
+                pixels[wordOffset] = (byte) xi;
+                pixels[wordOffset + 1] = (byte) yi;
+            }
+        }
+        final PixelData tile = Mockito.mock(PixelData.class);
+        Mockito.when(tile.getData()).thenReturn(ByteBuffer.wrap(pixels));
+        Mockito.when(tile.getOrder()).thenReturn(ByteOrder.LITTLE_ENDIAN);
+        return tile;
+    }
+
+    @Override
+    public int getByteWidth() {
+        return 2;
+    }
+
+    @Override
+    public boolean isSigned() {
+        return false;
+    }
+
+    @Override
+    public boolean isFloat() {
+        return false;
+    }
+
+    private static int getSizeX(int resolutionLevel) {
+        return 800 << resolutionLevel;
+    }
+
+    @Override
+    public int getSizeX() {
+        return getSizeX(resolutionLevel);
+    }
+
+    private static int getSizeY(int resolutionLevel) {
+        return 640 << resolutionLevel;
+    }
+
+    @Override
+    public int getSizeY() {
+        return getSizeY(resolutionLevel);
+    }
+
+    @Override
+    public int getSizeZ() {
+        return 1;
+    }
+
+    @Override
+    public int getSizeC() {
+        return 3;
+    }
+
+    @Override
+    public int getSizeT() {
+        return 30;
+    }
+
+    @Override
+    public int getResolutionLevels() {
+        return resolutionLevels;
+    }
+
+    @Override
+    public int getResolutionLevel() {
+        return resolutionLevel;
+    }
+
+    @Override
+    public void setResolutionLevel(int resolutionLevel) {
+        this.resolutionLevel = resolutionLevel;
+    }
+
+    @Override
+    public Dimension getTileSize() {
+        return new Dimension(256, 256);
+    }
+
+    @Override
+    public List<List<Integer>> getResolutionDescriptions() {
+        final ImmutableList.Builder<List<Integer>> resolutions = ImmutableList.builderWithExpectedSize(resolutionLevels);
+        for (int resolution = 0; resolution < resolutionLevels; resolution++) {
+            resolutions.add(ImmutableList.of(getSizeX(resolution), getSizeY(resolution)));
+        }
+        return resolutions.build().reverse();
+    }
+
+    /* All other methods simply throw. */
+
+    @Override
+    public void checkBounds(Integer x, Integer y, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getPlaneSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getRowSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getColSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getStackSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getTimepointSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getTotalSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getHypercubeSize(List<Integer> offset, List<Integer> size, List<Integer> step) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getRowOffset(Integer y, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getPlaneOffset(Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getStackOffset(Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long getTimepointOffset(Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getHypercube(List<Integer> offset, List<Integer> size, List<Integer> step) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getHypercubeDirect(List<Integer> offset, List<Integer> size, List<Integer> step, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getPlaneRegionDirect(Integer z, Integer c, Integer t, Integer count, Integer offset, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getTileDirect(Integer z, Integer c, Integer t, Integer x, Integer y, Integer w, Integer h, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getRegion(Integer size, Long offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getRegionDirect(Integer size, Long offset, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getRow(Integer y, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getCol(Integer x, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getRowDirect(Integer y, Integer z, Integer c, Integer t, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getColDirect(Integer x, Integer z, Integer c, Integer t, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getPlane(Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getPlaneRegion(Integer x, Integer y, Integer width, Integer height, Integer z, Integer c, Integer t, Integer stride) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getPlaneDirect(Integer z, Integer c, Integer t, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getStack(Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getStackDirect(Integer c, Integer t, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PixelData getTimepoint(Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getTimepointDirect(Integer t, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTile(byte[] buffer, Integer z, Integer c, Integer t, Integer x, Integer y, Integer w, Integer h) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRegion(Integer size, Long offset, byte[] buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRegion(Integer size, Long offset, ByteBuffer buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRow(ByteBuffer buffer, Integer y, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPlane(ByteBuffer buffer, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPlane(byte[] buffer, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStack(ByteBuffer buffer, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStack(byte[] buffer, Integer z, Integer c, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTimepoint(ByteBuffer buffer, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTimepoint(byte[] buffer, Integer t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] calculateMessageDigest() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getId() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Should suffice if Travis is green. `ZarrMetadataTest` has `ZarrEndpointsTestBase` broken out as a superclass because the chunking / tiling tests for the pixel data use it too, those can follow in another PR once done. Increases the visibility of a couple of things beyond `private` to make them directly testable.