### PR TITLE
Rechunk script

### DIFF
--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -45,9 +45,9 @@ def main():
                         help="array to copy from. must exist.")
     parser.add_argument("target_array",
                         help="array to write to. may not exist.")
-    parser.add_argument("chunks", default="1024,1024,1,1,1",
+    parser.add_argument("chunks", default="1,1,1,1024,1024")
                         help=("comma-separated string of chunk sizes "
-                              "(%(default)s)"))
+                              "(e.g. %(default)s)"))
     args = parser.parse_args()
 
     if args.distributed:

--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -37,11 +37,23 @@ def convert(resized, target_array):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dimensions", type=int, default="5")
-    parser.add_argument("source_array")
-    parser.add_argument("target_array")
-    parser.add_argument("chunks")
+    parser.add_argument("--dimensions", type=int, default="5", metavar="DIMS",
+                        help="number of chunks to parse (%(default)s)")
+    parser.add_argument("--distributed", action="store_true",
+                        help="enable distributed dashboard (%(default)s)")
+    parser.add_argument("source_array",
+                        help="array to copy from. must exist.")
+    parser.add_argument("target_array",
+                        help="array to write to. may not exist.")
+    parser.add_argument("chunks", default="1024,1024,1,1,1",
+                        help=("comma-separated string of chunk sizes "
+                              "(%(default)s)"))
     args = parser.parse_args()
+
+    if args.distributed:
+        from dask.distributed import Client
+        client = Client()
+        input("Visit http://localhost:8787/status - Press Enter to continue...")
 
     chunks = [int(x) for x in args.chunks.split(",")]
     assert len(chunks) == args.dimensions
@@ -53,6 +65,9 @@ def main():
         ),
         args.target_array
     )
+
+    if args.distributed:
+        input("Press Enter to exit...")
 
 
 if __name__ == "__main__":

--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import dask.array as da
+import argparse
+import time
+
+
+def timeit(method):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method.__name__.upper())
+            kw['log_time'][name] = int((te - ts) * 1000)
+        else:
+            print('%r  %2.2f ms' %
+                  (method.__name__, (te - ts) * 1000))
+        return result
+    return timed
+
+
+@timeit
+def load(source_array):
+    return da.from_zarr(source_array)
+
+
+@timeit
+def resize(arr, chunks):
+    return arr.rechunk(chunks)
+
+
+@timeit
+def convert(resized, target_array):
+    da.to_zarr(resized, target_array)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dimensions", type=int, default="5")
+    parser.add_argument("source_array")
+    parser.add_argument("target_array")
+    parser.add_argument("chunks")
+    args = parser.parse_args()
+
+    chunks = [int(x) for x in args.chunks.split(",")]
+    assert len(chunks) == args.dimensions
+
+    convert(
+        resize(
+            load(args.source_array),
+            chunks
+        ),
+        args.target_array
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -44,7 +44,7 @@ def main():
     parser.add_argument("source_array",
                         help="array to copy from. must exist.")
     parser.add_argument("target_array",
-                        help="array to write to. may not exist.")
+                        help="array to write to. must not exist.")
     parser.add_argument("chunks", default="1,1,1,1024,1024",
                         help=("comma-separated string of chunk sizes "
                               "(e.g. %(default)s)"))

--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -45,14 +45,14 @@ def main():
                         help="array to copy from. must exist.")
     parser.add_argument("target_array",
                         help="array to write to. may not exist.")
-    parser.add_argument("chunks", default="1,1,1,1024,1024")
+    parser.add_argument("chunks", default="1,1,1,1024,1024",
                         help=("comma-separated string of chunk sizes "
                               "(e.g. %(default)s)"))
     args = parser.parse_args()
 
     if args.distributed:
         from dask.distributed import Client
-        client = Client()
+        client = Client()  # noqa
         input("Visit http://localhost:8787/status - Press Enter to continue...")
 
     chunks = [int(x) for x in args.chunks.split(",")]


### PR DESCRIPTION
Permits copying an array from one Zarr store to another while applying a new chunk size. Dask `from_zarr` and `to_zarr` are used to perform this in parallel. For long running tasks, a dashboard can be activated with `--distributed` to watch the processing occur. Multiscale metadata will need to be updated for the Zarr group _after_ the fact.