### PR TITLE
Autoformat with black. Add travis stages.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: 19.10b0
+  hooks:
+  - id: black
+    # default black line length is 88
+    args: [--target-version=py35, --line-length=79]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+  - id: flake8
+    # default flake8 line length is 79

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
 language: java
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
 
-script:
-  - (cd ci && ./startminio.sh)
-  - export AWS_ACCESS_KEY_ID=stsadmin AWS_SECRET_ACCESS_KEY=stsadmin-secret
-  - gradle check
-  - gradle shadowJar
-  - docker build .
+jobs:
+  include:
+    # Default stage: test
+    - name: lint
+      language: python
+      install:
+        - python3 -mpip install pre-commit
+      script:
+        - pre-commit run --all-files
+    - name: java
+      before_cache:
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      cache:
+        directories:
+          - $HOME/.gradle/caches/
+          - $HOME/.gradle/wrapper/
+      script:
+        - (cd ci && ./startminio.sh)
+        - export AWS_ACCESS_KEY_ID=stsadmin AWS_SECRET_ACCESS_KEY=stsadmin-secret
+        - gradle check
+        - gradle shadowJar
+    - name: docker
+      language: generic
+      script:
+        - docker build .

--- a/examples/basic-http/create-zarr.py
+++ b/examples/basic-http/create-zarr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import zarr
-store = zarr.DirectoryStore('dir.zarr')
+
+store = zarr.DirectoryStore("dir.zarr")
 group = zarr.group(store=store, overwrite=True)
 group.attrs["example"] = True
 z = group.zeros("test", shape=(4, 4))

--- a/examples/basic-http/explore-zarr.py
+++ b/examples/basic-http/explore-zarr.py
@@ -2,6 +2,7 @@
 
 import zarr
 from zarr.storage import FSStore
+
 store = FSStore("http://localhost:8000")
 group = zarr.group(store=store)
 print(group.attrs["example"])

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import os
 
-import omero.clients
 from omero.cli import cli_login
 from omero.gateway import BlitzGateway
 

--- a/src/scripts/omero_to_zarr.py
+++ b/src/scripts/omero_to_zarr.py
@@ -1,4 +1,3 @@
-
 import argparse
 import sys
 import os
@@ -15,6 +14,7 @@ import zarr
 # $ python omero_to_zarr.py 123
 # will create 123.zarr
 
+
 def image_to_zarr(image):
 
     size_c = image.getSizeC()
@@ -25,7 +25,7 @@ def image_to_zarr(image):
 
     # dir for caching .npy planes
     os.makedirs(str(image.id), mode=511, exist_ok=True)
-    name = '%s.zarr' % image.id
+    name = "%s.zarr" % image.id
     za = None
     pixels = image.getPrimaryPixels()
 
@@ -34,9 +34,11 @@ def image_to_zarr(image):
         for c in range(size_c):
             for z in range(size_z):
                 # We only want to load from server if not cached locally
-                filename = '{}/{:03d}-{:03d}-{:03d}.npy'.format(image.id, z, c, t)
+                filename = "{}/{:03d}-{:03d}-{:03d}.npy".format(
+                    image.id, z, c, t
+                )
                 if not os.path.exists(filename):
-                    zct_list.append( (z,c,t) )
+                    zct_list.append((z, c, t))
 
     def planeGen():
         planes = pixels.getPlanes(zct_list)
@@ -48,38 +50,40 @@ def image_to_zarr(image):
     for t in range(size_t):
         for c in range(size_c):
             for z in range(size_z):
-                filename = '{}/{:03d}-{:03d}-{:03d}.npy'.format(image.id, z, c, t)
+                filename = "{}/{:03d}-{:03d}-{:03d}.npy".format(
+                    image.id, z, c, t
+                )
                 if os.path.exists(filename):
-                    print('plane (from disk) c:%s, t:%s, z:%s' % (c, t, z))
+                    print("plane (from disk) c:%s, t:%s, z:%s" % (c, t, z))
                     plane = numpy.load(filename)
                 else:
-                    print('loading plane c:%s, t:%s, z:%s' % (c, t, z))
+                    print("loading plane c:%s, t:%s, z:%s" % (c, t, z))
                     plane = next(planes)
                     numpy.save(filename, plane)
                 if za is None:
                     store = zarr.DirectoryStore(name)
                     root = zarr.group(store=store, overwrite=True)
                     za = root.create(
-                        '0',
+                        "0",
                         shape=(size_t, size_c, size_z, size_y, size_x),
                         chunks=(1, 1, 1, size_y, size_x),
-                        dtype=plane.dtype
+                        dtype=plane.dtype,
                     )
-                print('t, c, z,' , t, c, z, plane.shape)
+                print("t, c, z,", t, c, z, plane.shape)
                 za[t, c, z, :, :] = plane
     print("Created", name)
 
 
 def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument('image_id', help='Image ID')
+    parser.add_argument("image_id", help="Image ID")
     args = parser.parse_args(argv)
 
     with cli_login() as cli:
         conn = BlitzGateway(client_obj=cli._client)
-        image = conn.getObject('Image', args.image_id)
+        image = conn.getObject("Image", args.image_id)
         image_to_zarr(image)
 
-if __name__ == '__main__':
-    main(sys.argv[1:])
 
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/scripts/rechunk.py
+++ b/src/scripts/rechunk.py
@@ -10,13 +10,13 @@ def timeit(method):
         ts = time.time()
         result = method(*args, **kw)
         te = time.time()
-        if 'log_time' in kw:
-            name = kw.get('log_name', method.__name__.upper())
-            kw['log_time'][name] = int((te - ts) * 1000)
+        if "log_time" in kw:
+            name = kw.get("log_name", method.__name__.upper())
+            kw["log_time"][name] = int((te - ts) * 1000)
         else:
-            print('%r  %2.2f ms' %
-                  (method.__name__, (te - ts) * 1000))
+            print("%r  %2.2f ms" % (method.__name__, (te - ts) * 1000))
         return result
+
     return timed
 
 
@@ -37,34 +37,41 @@ def convert(resized, target_array):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dimensions", type=int, default="5", metavar="DIMS",
-                        help="number of chunks to parse (%(default)s)")
-    parser.add_argument("--distributed", action="store_true",
-                        help="enable distributed dashboard (%(default)s)")
-    parser.add_argument("source_array",
-                        help="array to copy from. must exist.")
-    parser.add_argument("target_array",
-                        help="array to write to. must not exist.")
-    parser.add_argument("chunks", default="1,1,1,1024,1024",
-                        help=("comma-separated string of chunk sizes "
-                              "(e.g. %(default)s)"))
+    parser.add_argument(
+        "--dimensions",
+        type=int,
+        default="5",
+        metavar="DIMS",
+        help="number of chunks to parse (%(default)s)",
+    )
+    parser.add_argument(
+        "--distributed",
+        action="store_true",
+        help="enable distributed dashboard (%(default)s)",
+    )
+    parser.add_argument("source_array", help="array to copy from. must exist.")
+    parser.add_argument(
+        "target_array", help="array to write to. must not exist."
+    )
+    parser.add_argument(
+        "chunks",
+        default="1,1,1,1024,1024",
+        help=("comma-separated string of chunk sizes " "(e.g. %(default)s)"),
+    )
     args = parser.parse_args()
 
     if args.distributed:
         from dask.distributed import Client
+
         client = Client()  # noqa
-        input("Visit http://localhost:8787/status - Press Enter to continue...")
+        input(
+            "Visit http://localhost:8787/status - Press Enter to continue..."
+        )
 
     chunks = [int(x) for x in args.chunks.split(",")]
     assert len(chunks) == args.dimensions
 
-    convert(
-        resize(
-            load(args.source_array),
-            chunks
-        ),
-        args.target_array
-    )
+    convert(resize(load(args.source_array), chunks), args.target_array)
 
     if args.distributed:
         input("Press Enter to exit...")


### PR DESCRIPTION
Closes https://github.com/ome/omero-ms-zarr/issues/24

To reformat Python code files after editting simply run `pre-commit run -a`.

This also splits Travis into three stages so it's easier to see whats failed.