### PR TITLE
Make microservice configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,31 @@ for querying role IDs from an OMERO database.
 
 Put your OMERO server configuration into `etc/omero.properties`, run
 
-    gradle run --args='etc/omero.properties'
+    gradle run --args=etc/omero.properties
 
 and try
 
-    src/scripts/fetch-ms-zarr.py -h
+    src/scripts/fetch-ms-zarr.py --endpoint-url http://localhost:8080/ --url-format '{url}image/{image}.zarr/' 1234
+
+
+### Configuration
+
+`etc/omero.properties` may include:
+
+`omero.ms.zarr.buffer-cache.size`
+: pixel buffer cache size, default 16
+
+`omero.ms.zarr.chunk.size.min`
+: minimum chunk size (not guaranteed), default 1048576; applies before compression
+
+`omero.ms.zarr.compress.zlib.level`
+: zlib compression level for chunks, default 6
+
+`omero.ms.zarr.net.path.image`
+: URI template path for getting image data, default `/image/{image}.zarr/` where `{image}` signifies the image ID and is mandatory
+
+`omero.ms.zarr.net.port`
+: the TCP port on which the HTTP server should listen, default 8080
 
 
 ## Build jar with dependencies

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ for querying role IDs from an OMERO database.
 
 ## Run
 
-Put your OMERO server configuration into `etc/omero.properties`, run
+Copy your OMERO.server configuration `etc/omero.properties` to the
+microservice then,
 
     gradle run --args=etc/omero.properties
 
@@ -22,8 +23,8 @@ and try
 
 ### Configuration
 
-In addition to your usual OMERO.server configuration
-`etc/omero.properties` may include:
+In addition to your usual OMERO.server configuration, the microservice's
+`etc/omero.properties` may also include:
 
 `omero.ms.zarr.buffer-cache.size`
 : pixel buffer cache size, default 16

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and try
 
 ### Configuration
 
+In addition to your usual OMERO.server configuration
 `etc/omero.properties` may include:
 
 `omero.ms.zarr.buffer-cache.size`

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
@@ -19,15 +19,19 @@
 
 package org.openmicroscopy.ms.zarr;
 
+import ome.io.nio.PixelsService;
+
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
+
+import com.google.common.collect.ImmutableMap;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
-import ome.io.nio.PixelsService;
 
 import org.hibernate.SessionFactory;
 import org.springframework.context.ApplicationContext;
@@ -56,6 +60,20 @@ public class ZarrDataService {
             }
             propertiesSystem.putAll(propertiesNew);
         }
+        /* determine microservice configuration from system properties */
+        final ImmutableMap.Builder<String, String> configuration = ImmutableMap.builder();
+        final String configurationPrefix = "omero.ms.zarr.";
+        for (final Map.Entry<Object, Object> property : propertiesSystem.entrySet()) {
+            final Object keyObject = property.getKey();
+            final Object valueObject = property.getValue();
+            if (keyObject instanceof String && valueObject instanceof String) {
+                final String key = (String) keyObject;
+                final String value = (String) valueObject;
+                if (key.startsWith(configurationPrefix)) {
+                    configuration.put(key.substring(configurationPrefix.length()), value);
+                }
+            }
+        }
         /* start up enough of OMERO.server to operate the pixels service */
         final AbstractApplicationContext zarrContext = new ClassPathXmlApplicationContext("zarr-context.xml");
         final ApplicationContext omeroContext = zarrContext.getBean("zarr.data", ApplicationContext.class);
@@ -63,7 +81,7 @@ public class ZarrDataService {
         final PixelsService pixelsService = omeroContext.getBean("/OMERO/Pixels", PixelsService.class);
         /* deploy the verticle which uses the pixels service */
         final Vertx vertx = Vertx.vertx();
-        final Verticle verticle = new ZarrDataVerticle(sessionFactory, pixelsService);
+        final Verticle verticle = new ZarrDataVerticle(configuration.build(), sessionFactory, pixelsService);
         vertx.deployVerticle(verticle, (AsyncResult<String> result) -> {
             zarrContext.close();
         });

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -26,7 +26,10 @@ import ome.io.nio.PixelsService;
 import ome.model.core.Pixels;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableMap;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -101,7 +104,9 @@ public abstract class ZarrEndpointsTestBase {
         Mockito.when(httpRequest.method()).thenReturn(HttpMethod.GET);
         Mockito.when(httpRequest.response()).thenReturn(httpResponse);
         Mockito.when(context.request()).thenReturn(httpRequest);
-        handler = new RequestHandlerForImage(sessionFactoryMock, pixelsServiceMock, URI_PATH_PREFIX);
+        final String URI = URI_PATH_PREFIX + '/' + Configuration.PLACEHOLDER_IMAGE_ID + '/';
+        final Map<String, String> configuration = ImmutableMap.of(Configuration.CONF_NET_PATH_IMAGE, URI);
+        handler = new RequestHandlerForImage(new Configuration(configuration), sessionFactoryMock, pixelsServiceMock);
     }
 
     /**


### PR DESCRIPTION
Adds microservice configuration properties,

- `omero.ms.zarr.buffer-cache.size`
- `omero.ms.zarr.chunk.size.min`
- `omero.ms.zarr.compress.zlib.level`
- `omero.ms.zarr.net.path.image`
- `omero.ms.zarr.net.port`

and describes them in the [README](https://github.com/mtbc/omero-ms-zarr/blob/configuration-properties/README.md).