### PR TITLE
Optionally add CONFIG_ env-vars to properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 RUN apk add --no-cache bash
 COPY --from=build /omero-ms-zarr-shadow/ .
 
-# Presumably the micro-service listens on a port, but there's no documentation on what it is or how to change it
-# PORT
-CMD ["omero-ms-zarr", "/etc/omero.properties"]
+EXPOSE 8080
+ENTRYPOINT ["java", "-cp", "/lib/omero-ms-zarr-0.1.1-SNAPSHOT-all.jar", "org.openmicroscopy.ms.zarr.ConfigEnv"]

--- a/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
@@ -1,0 +1,30 @@
+package org.openmicroscopy.ms.zarr;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+
+public class ConfigEnv {
+    /**
+     * Converts configuration environment variables beginning with "CONFIG_" to OMERO configuration properties
+     * and runs the microservice.
+     * Since "." is not allowed in a variable name "." must be replaced by "_", and "_" by "__".
+     * For example "CONFIG_omero_data_dir=/OMERO" will become "omero.data.dir=/OMERO"
+     *
+     * @param argv filename(s) from which to read configuration beyond current Java system properties
+     * @throws IOException if the configuration could not be loaded
+     */
+    public static void main(String[] argv) throws IOException {
+        Properties overrides = new Properties();
+        for (Iterator<Map.Entry<String, String>> i = System.getenv().entrySet().iterator(); i.hasNext();) {
+            Map.Entry<String, String> e = i.next();
+            if (e.getKey().startsWith("CONFIG_")) {
+                String key = e.getKey().substring(7);
+                key = key.replaceAll("([^_])_([^_])", "$1.$2").replaceAll("__", "_");
+                overrides.put(key, e.getValue());
+            }
+        }
+        ZarrDataService.mainVerticle(argv, overrides);
+    }
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
@@ -20,7 +20,6 @@
 package org.openmicroscopy.ms.zarr;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
@@ -36,8 +35,7 @@ public class ConfigEnv {
      */
     public static void main(String[] argv) throws IOException {
         Properties overrides = new Properties();
-        for (Iterator<Map.Entry<String, String>> i = System.getenv().entrySet().iterator(); i.hasNext();) {
-            Map.Entry<String, String> e = i.next();
+        for (final Map.Entry<String, String> e : System.getenv().entrySet()) {
             if (e.getKey().startsWith("CONFIG_")) {
                 String key = e.getKey().substring(7);
                 key = key.replaceAll("([^_])_([^_])", "$1.$2").replaceAll("__", "_");

--- a/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ConfigEnv.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package org.openmicroscopy.ms.zarr;
 
 import java.io.IOException;

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
@@ -58,7 +58,7 @@ public class ZarrDataService {
      * Run the microservice configured using properties files with optional overrides
      * @param argv filename(s) from which to read configuration beyond current Java system properties
      * @param overrides Override properties obtained from files with these properties
-     * @throws IOException
+     * @throws IOException if the configuration could not be loaded
      */
     static void mainVerticle(String[] argv, Properties overrides) throws IOException {
         /* set system properties from named configuration files */

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
@@ -51,6 +51,16 @@ public class ZarrDataService {
      * @throws IOException if the configuration could not be loaded
      */
     public static void main(String[] argv) throws IOException {
+        mainVerticle(argv, null);
+    }
+
+    /**
+     * Run the microservice configured using properties files with optional overrides
+     * @param argv filename(s) from which to read configuration beyond current Java system properties
+     * @param overrides Override properties obtained from files with these properties
+     * @throws IOException
+     */
+    static void mainVerticle(String[] argv, Properties overrides) throws IOException {
         /* set system properties from named configuration files */
         final Properties propertiesSystem = System.getProperties();
         for (final String filename : argv) {
@@ -59,6 +69,9 @@ public class ZarrDataService {
                 propertiesNew.load(filestream);
             }
             propertiesSystem.putAll(propertiesNew);
+        }
+        if (overrides != null) {
+            propertiesSystem.putAll(overrides);
         }
         /* determine microservice configuration from system properties */
         final ImmutableMap.Builder<String, String> configuration = ImmutableMap.builder();

--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataService.java
@@ -57,7 +57,7 @@ public class ZarrDataService {
     /**
      * Run the microservice configured using properties files with optional overrides
      * @param argv filename(s) from which to read configuration beyond current Java system properties
-     * @param overrides Override properties obtained from files with these properties
+     * @param overrides override properties obtained from files with these properties
      * @throws IOException if the configuration could not be loaded
      */
     static void mainVerticle(String[] argv, Properties overrides) throws IOException {


### PR DESCRIPTION
This should allow the Docker image to be run using the same configuration format as the omero-web and omero-server containers.

For example, https://github.com/ome/docker-example-omero with these changes:
```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 60fd75c..efc64d5 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,21 @@ services:
     volumes:
       - "omero:/OMERO"

+  omerozarr:
+    image: omero-ms-zarr
+    environment:
+      CONFIG_omero_db_host: database
+      CONFIG_omero_db_user: omero
+      CONFIG_omero_db_pass: omero
+      CONFIG_omero_db_name: omero
+      CONFIG_omero_ms_zarr_net_path_image: /idr/zarr/v0.1/{image}.zarr/
+    networks:
+      - omero
+    ports:
+      - "8080:8080"
+    volumes:
+      - "omero:/OMERO"
+
   omeroweb:
     image: "openmicroscopy/omero-web-standalone:5.6"
     environment:
```

Import an image, then check:
```
$ curl http://localhost:8080/idr/zarr/v0.1/1.zarr/.zattrs
{"multiscales":[{"datasets":[{"path":"0","scale":1.0}],"version":"0.1"}]}
```