### PR TITLE
Adjust metadata that microservice includes in .zattrs

### DIFF
--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -58,6 +58,7 @@ import ome.model.display.ChannelBinding;
 import ome.model.display.CodomainMapContext;
 import ome.model.display.RenderingDef;
 import ome.model.display.ReverseIntensityContext;
+import ome.model.enums.RenderingModel;
 import ome.model.stats.StatsInfo;
 import ome.util.PixelData;
 
@@ -436,7 +437,7 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
             final Map<String, Object> rdefs = new HashMap<>();
             rdefs.put("defaultZ", rdef.getDefaultZ());
             rdefs.put("defaultT", rdef.getDefaultT());
-            if (rdef.getModel().getValue().equals("greyscale")) {
+            if (RenderingModel.VALUE_GREYSCALE.equals(rdef.getModel().getValue())) {
                 rdefs.put("model", "greyscale");
             } else {
                 /* probably "rgb" */

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -442,7 +442,8 @@ public class RequestHandlerForImage implements Handler<RoutingContext> {
             final Map<String, Object> dataset = new HashMap<>();
             dataset.put("path", Integer.toString(resolution++));
             if (scale != null) {
-                dataset.put("scale", scale);
+                /* dataset.put("scale", scale);
+                 * scale is omitted while it is being rethought */
             }
             datasets.add(dataset);
         }

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -23,9 +23,13 @@ import org.openmicroscopy.ms.zarr.stub.PixelBufferFake;
 
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
+import ome.model.core.Image;
 import ome.model.core.Pixels;
+import ome.model.internal.Details;
+import ome.model.meta.Experimenter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -91,13 +95,32 @@ public abstract class ZarrEndpointsTestBase {
     private RequestHandlerForImage handler;
 
     /**
+     * Set up a mock pixels object from which to source OMERO metadata.
+     * @return a mock pixels object
+     */
+    private static Pixels constructMockPixels() {
+        final Pixels pixels = Mockito.mock(Pixels.class);
+        final Image image = Mockito.mock(Image.class);
+        final Details details = Mockito.mock(Details.class);
+        final Experimenter owner = new Experimenter(1L, false);
+        Mockito.when(pixels.getImage()).thenReturn(image);
+        Mockito.when(pixels.getDetails()).thenReturn(details);
+        Mockito.when(pixels.iterateSettings()).thenReturn(Collections.emptyIterator());
+        Mockito.when(image.getId()).thenReturn(1L);
+        Mockito.when(image.getName()).thenReturn("test image");
+        Mockito.when(details.getOwner()).thenReturn(owner);
+        return pixels;
+    }
+
+    /**
      * Set up the HTTP request handler atop mock services. Can be used to reset the mocks in between requests.
      * @throws IOException unexpected
      */
     @BeforeEach
     protected void mockSetup() throws IOException {
         MockitoAnnotations.initMocks(this);
-        Mockito.when(query.uniqueResult()).thenReturn(new Pixels());
+        final Pixels pixels = constructMockPixels();
+        Mockito.when(query.uniqueResult()).thenReturn(pixels);
         Mockito.when(sessionMock.createQuery(Mockito.anyString())).thenReturn(query);
         Mockito.when(sessionFactoryMock.openSession()).thenReturn(sessionMock);
         Mockito.when(pixelsServiceMock.getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false))).thenReturn(pixelBuffer);

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -75,7 +75,7 @@ public class ZarrMetadataTest extends ZarrEndpointsTestBase {
     @Test
     public void testZarrAttrs() {
         final JsonObject response = getResponseAsJson(0, ".zattrs");
-        assertNoExtraKeys(response, "multiscales");
+        assertNoExtraKeys(response, "multiscales", "omero");
         final JsonArray multiscales = response.getJsonArray("multiscales");
         Assertions.assertEquals(1, multiscales.size());
         final JsonObject multiscale = multiscales.getJsonObject(0);

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -83,10 +83,12 @@ public class ZarrMetadataTest extends ZarrEndpointsTestBase {
             assertNoExtraKeys(dataset, "path", "scale");
             final String path = dataset.getString("path");
             Assertions.assertNotNull(path);
+            @SuppressWarnings("unused")
             final Double scale = dataset.getDouble("scale");
             if (isScale1) {
                 /* The first group listed is for the full-size image. */
-                Assertions.assertEquals(1, scale);
+                /* Assertions.assertEquals(1, scale);
+                 * scale is omitted while it is being rethought */
                 isScale1 = false;
             }
             paths.add(path);


### PR DESCRIPTION
Replaces `scale` with an initial pass at OMERO metadata. Fixes #30 and #31.