### PR TITLE
Log the failure to start HTTP server listening.

### DIFF
--- a/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataVerticle.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/ZarrDataVerticle.java
@@ -69,11 +69,11 @@ public class ZarrDataVerticle implements Verticle {
         @Override
         public void handle(AsyncResult<X> result) {
             if (result.succeeded()) {
-                LOGGER.info("succeeded: " + action);
+                LOGGER.info("succeeded: {}", action);
                 promise.complete();
             } else {
                 final Throwable cause = result.cause();
-                LOGGER.error("failed: " + action, cause);
+                LOGGER.error("failed: {}", action, cause);
                 promise.fail(cause);
             }
         }


### PR DESCRIPTION
This PR reworks the verticle a little more to fit Vert.x conventions. Notably, if you try something disabling, like setting `omero.ms.zarr.net.port=80` but running as an unprivileged user, the log output should include a useful ERROR line. Fixes #37.