### PR TITLE
allow microservice to offer multi-Z chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ In addition to your usual OMERO.server configuration, the microservice's
 `omero.ms.zarr.buffer-cache.size`
 : pixel buffer cache size, default 16
 
+`omero.ms.zarr.chunk.size.adjust`
+: ordered list of dimensions to adjust to increase chunk size, default *XYZ*; *C* and *T* are not offered
+
 `omero.ms.zarr.chunk.size.min`
 : minimum chunk size (not guaranteed), default 1048576; applies before compression
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,5 +59,6 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+        maxGranularity 2
     }
 }

--- a/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
@@ -24,10 +24,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.SortedSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,9 @@ public class Configuration {
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     public final static String PLACEHOLDER_IMAGE_ID = "{image}";
+
+    private final static SortedSet<Character> VALID_DIMENSIONS =
+            ImmutableSortedSet.copyOf(RequestHandlerForImage.DataShape.ADJUSTERS.keySet());
 
     /* Configuration keys for the map provided to the constructor. */
     public final static String CONF_BUFFER_CACHE_SIZE = "buffer-cache.size";
@@ -127,18 +131,18 @@ public class Configuration {
         }
 
         if (chunkSizeAdjust != null) {
-            final Set<Character> validDimensions = new HashSet<>(RequestHandlerForImage.DataShape.ADJUSTERS.keySet());
+            final Set<Character> validDimensionsRemaining = new HashSet<>(VALID_DIMENSIONS);
             final ImmutableList.Builder<Character> dimensions = ImmutableList.builder();
             for (int index = 0; index < chunkSizeAdjust.length();) {
                 final int codePoint = Character.toUpperCase(chunkSizeAdjust.codePointAt(index));
                 final int charCount = Character.charCount(codePoint);
                 if (charCount == 1) {
                     final char dimension = Character.toChars(codePoint)[0];
-                    if (validDimensions.remove(dimension)) {
+                    if (validDimensionsRemaining.remove(dimension)) {
                         dimensions.add(dimension);
                     } else if (Character.isAlphabetic(codePoint)) {
                         final StringBuilder message = new StringBuilder("chunk size adjustment may contain (without repeats): ");
-                        for (final char validDimension : new TreeSet<>(RequestHandlerForImage.DataShape.ADJUSTERS.keySet())) {
+                        for (final char validDimension : VALID_DIMENSIONS) {
                             message.append(validDimension);
                         }
                         LOGGER.error(message.toString());

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -171,6 +171,34 @@ public class RequestHandlerForImage implements HttpHandler {
             }
             return this;
         }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("XYZCT: full=");
+            sb.append(xSize);
+            sb.append('×');
+            sb.append(ySize);
+            sb.append('×');
+            sb.append(zSize);
+            sb.append('×');
+            sb.append(cSize);
+            sb.append('×');
+            sb.append(tSize);
+            sb.append(" tile=");
+            sb.append(xTile);
+            sb.append('×');
+            sb.append(yTile);
+            sb.append('×');
+            sb.append(zTile);
+            sb.append('×');
+            sb.append(1);
+            sb.append('×');
+            sb.append(1);
+            sb.append(" bytes=");
+            sb.append(byteWidth);
+            return sb.toString();
+        }
     }
 
     private final PixelsService pixelsService;

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -74,7 +74,7 @@ public class RequestHandlerForImage implements HttpHandler {
         final int xSize, ySize, cSize, zSize, tSize;
         final int byteWidth;
 
-        int xTile, yTile;
+        int xTile, yTile, zTile;
 
         /**
          * @param buffer the pixel buffer from which to extract the dimensionality
@@ -94,20 +94,23 @@ public class RequestHandlerForImage implements HttpHandler {
                 xTile = tileSize.width;
                 yTile = tileSize.height;
             }
+            zTile = 1;
 
             byteWidth = buffer.getByteWidth();
         }
 
         /**
-         * Attempt to increase the <em>X</em>, <em>Y</em> tile size so the tile occupies at least the given number of bytes.
+         * Attempt to increase the <em>X</em>, <em>Y</em>, <em>Z</em> tile size so the tile occupies at least the given number of
+         * bytes.
          * @param target the minimum target size, in bytes
          * @return this, for method chaining
          */
         DataShape adjustTileSize(int target) {
             final int pixelTarget = target / byteWidth;
-            while ((long) xTile * yTile < pixelTarget) {
+            while ((long) xTile * yTile * zTile < pixelTarget) {
                 final boolean isIncreaseX = xTile < xSize;
                 final boolean isIncreaseY = yTile < ySize;
+                final boolean isIncreaseZ = zTile < zSize;
                 if (isIncreaseX && xTile * 3 >= xSize) {
                     xTile = xSize;
                 } else if (isIncreaseY && yTile * 3 >= ySize) {
@@ -116,6 +119,11 @@ public class RequestHandlerForImage implements HttpHandler {
                     xTile <<= 1;
                 } else if (isIncreaseY) {
                     yTile <<= 1;
+                } else if (isIncreaseZ) {
+                    zTile <<= 1;
+                    /* Spread planes evenly across chunks. */
+                    final int zCount = (zSize + zTile - 1) / zTile;
+                    zTile = (zSize + zCount - 1) / zCount;
                 } else {
                     break;
                 }
@@ -460,7 +468,7 @@ public class RequestHandlerForImage implements HttpHandler {
         result.put("zarr_format", 2);
         result.put("order", "C");
         result.put("shape", ImmutableList.of(shape.tSize, shape.cSize, shape.zSize, shape.ySize, shape.xSize));
-        result.put("chunks", ImmutableList.of(1, 1, 1, shape.yTile, shape.xTile));
+        result.put("chunks", ImmutableList.of(1, 1, shape.zTile, shape.yTile, shape.xTile));
         result.put("fill_value", 0);
         final char byteOrder = shape.byteWidth == 1 ? '|' : isLittleEndian ? '<' : '>';
         final char byteType = isFloat ? 'f' : isSigned ? 'i' : 'u';
@@ -495,13 +503,16 @@ public class RequestHandlerForImage implements HttpHandler {
             final DataShape shape = new DataShape(buffer).adjustTileSize(chunkSize);
             final int x = shape.xTile * chunkId.get(4);
             final int y = shape.yTile * chunkId.get(3);
-            final int z = chunkId.get(2);
+            final int z = shape.zTile * chunkId.get(2);
             final int c = chunkId.get(1);
             final int t = chunkId.get(0);
             if (x >= shape.xSize || y >= shape.ySize || c >= shape.cSize || z >= shape.zSize || t >= shape.tSize) {
                 fail(response, 404, "no chunk with that index");
                 return;
             }
+            chunk = new byte[shape.xTile * shape.yTile * shape.zTile * shape.byteWidth];
+            for (int plane = 0; plane < shape.zTile && z + plane < shape.zSize; plane++) {
+            final int planeOffset = plane * (chunk.length / shape.zTile);
             final PixelData tile;
             if (x + shape.xTile > shape.xSize) {
                 /* a tile that crosses the right side of the image */
@@ -514,29 +525,30 @@ public class RequestHandlerForImage implements HttpHandler {
                     /* does not cross the bottom side */
                     yd = shape.yTile;
                 }
-                tile = buffer.getTile(z, c, t, x, y, xd, yd);
+                tile = buffer.getTile(z + plane, c, t, x, y, xd, yd);
                 final byte[] chunkSrc = tile.getData().array();
-                chunk = new byte[shape.xTile * shape.yTile * shape.byteWidth];
-                /* must now assemble row-by-row into a full-sized chunk */
+                /* must now assemble row-by-row into a plane in the chunk */
                 for (int row = 0; row < yd; row++) {
                     final int srcIndex = row * xd * shape.byteWidth;
-                    final int dstIndex = row * shape.xTile * shape.byteWidth;
+                    final int dstIndex = row * shape.xTile * shape.byteWidth + planeOffset;
                     System.arraycopy(chunkSrc, srcIndex, chunk, dstIndex, xd * shape.byteWidth);
                 }
-            } else if (y + shape.yTile > shape.ySize) {
-                /* a tile that crosses the bottom of the image */
-                final int yd = shape.ySize - y;
-                tile = buffer.getTile(z, c, t, x, y, shape.xTile, yd);
-                final byte[] chunkSrc = tile.getData().array();
-                chunk = new byte[shape.xTile * shape.yTile * shape.byteWidth];
-                /* simply copy into the first part of the chunk */
-                System.arraycopy(chunkSrc, 0, chunk, 0, chunkSrc.length);
             } else {
-                /* the tile fills a chunk */
-                tile = buffer.getTile(z, c, t, x, y, shape.xTile, shape.yTile);
-                chunk = tile.getData().array();
+                final int yd;
+                if (y + shape.yTile > shape.ySize) {
+                /* a tile that crosses the bottom of the image */
+                    yd = shape.ySize - y;
+                } else {
+                /* the tile fills a plane in the chunk */
+                    yd = shape.yTile;
+                }
+                tile = buffer.getTile(z + plane, c, t, x, y, shape.xTile, yd);
+                final byte[] chunkSrc = tile.getData().array();
+                /* simply copy into the plane */
+                System.arraycopy(chunkSrc, 0, chunk, planeOffset, chunkSrc.length);
             }
             tile.dispose();
+            }
         } catch (Exception e) {
             fail(response, 500, "query failed");
             return;

--- a/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
@@ -168,15 +168,23 @@ public class TileSizeAdjustmentTest {
                     if (isAdjustZ) {
                         adjusters.add(ADJUSTER_Z);
                     }
+                    final int[] deciFactorsPlane, deciFactorsTile;
+                    if (isAdjustX && isAdjustY && isAdjustZ) {
+                        deciFactorsPlane = new int[] {1, 3, 7, 10, 15, 25, 45};
+                        deciFactorsTile = new int[] {1, 3, 7, 10, 15};
+                    } else {
+                        deciFactorsPlane = new int[] {3, 10, 25};
+                        deciFactorsTile = new int[] {1, 7, 15};
+                    }
                     for (int bytes : new int[] {1, 2, 4}) {
                         for (final int chunkSide : new int[] {1000, 1024}) {
-                            for (int xDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                            for (int xDeciFactor : deciFactorsPlane) {
                                 final int x = chunkSide * xDeciFactor / 10;
-                                for (int yDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                                for (int yDeciFactor : deciFactorsPlane) {
                                     final int y = chunkSide * yDeciFactor / 10;
-                                    for (int wDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                                    for (int wDeciFactor : deciFactorsTile) {
                                         final int w = chunkSide * wDeciFactor / 10;
-                                        for (int hDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                                        for (int hDeciFactor : deciFactorsTile) {
                                             final int h = chunkSide * hDeciFactor / 10;
                                             final DataShape shape = getDataShape(x, y, bytes);
                                             shape.xTile = w;

--- a/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
@@ -24,7 +24,11 @@ import org.openmicroscopy.ms.zarr.RequestHandlerForImage.DataShape;
 import ome.io.nio.PixelBuffer;
 
 import java.awt.Dimension;
+import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,6 +42,9 @@ import org.mockito.Mockito;
  * @author m.t.b.carroll@dundee.ac.uk
  */
 public class TileSizeAdjustmentTest {
+
+    private static final List<Function<DataShape, Boolean>> ADJUSTERS = ImmutableList.of(
+            DataShape.ADJUSTERS.get('X'), DataShape.ADJUSTERS.get('Y'), DataShape.ADJUSTERS.get('Z'));
 
     /**
      * Create a {@link DataShape} for the given image plane dimensionality.
@@ -72,7 +79,7 @@ public class TileSizeAdjustmentTest {
         final int beforeHeight = shape.yTile;
         final int beforePlanes = shape.zTile;
         final int beforeChunkSize = beforeWidth * beforeHeight * beforePlanes * shape.byteWidth;
-        shape.adjustTileSize(targetChunkSize);
+        shape.adjustTileSize(ADJUSTERS, targetChunkSize);
         final int afterWidth = shape.xTile;
         final int afterHeight = shape.yTile;
         final int afterPlanes = shape.zTile;

--- a/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/TileSizeAdjustmentTest.java
@@ -168,25 +168,25 @@ public class TileSizeAdjustmentTest {
                     if (isAdjustZ) {
                         adjusters.add(ADJUSTER_Z);
                     }
-        for (int bytes : new int[] {1, 2, 4}) {
-            for (final int chunkSide : new int[] {1000, 1024}) {
-                for (int xDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
-                    final int x = chunkSide * xDeciFactor / 10;
-                    for (int yDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
-                        final int y = chunkSide * yDeciFactor / 10;
-                        for (int wDeciFactor : new int[] {1, 3, 7, 10, 15}) {
-                            final int w = chunkSide * wDeciFactor / 10;
-                            for (int hDeciFactor : new int[] {1, 3, 7, 10, 15}) {
-                                final int h = chunkSide * hDeciFactor / 10;
-                                final DataShape shape = getDataShape(x, y, bytes);
-                                shape.xTile = w;
-                                shape.yTile = h;
-                                arguments.add(Arguments.of(shape, chunkSide * chunkSide, adjusters.build()));
+                    for (int bytes : new int[] {1, 2, 4}) {
+                        for (final int chunkSide : new int[] {1000, 1024}) {
+                            for (int xDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                                final int x = chunkSide * xDeciFactor / 10;
+                                for (int yDeciFactor : new int[] {1, 3, 7, 10, 15, 25, 45}) {
+                                    final int y = chunkSide * yDeciFactor / 10;
+                                    for (int wDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                                        final int w = chunkSide * wDeciFactor / 10;
+                                        for (int hDeciFactor : new int[] {1, 3, 7, 10, 15}) {
+                                            final int h = chunkSide * hDeciFactor / 10;
+                                            final DataShape shape = getDataShape(x, y, bytes);
+                                            shape.xTile = w;
+                                            shape.yTile = h;
+                                            arguments.add(Arguments.of(shape, chunkSide * chunkSide, adjusters.build()));
+                                        }
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-            }
                     }
                 }
             }


### PR DESCRIPTION
`omero.ms.zarr.chunk.size.min` defaults to trying to have chunks include at least 1MB of data when uncompressed. This PR fixes #14 by allowing the microservice to include multiple Z planes in a chunk in reaching that minimum. Pick a multi-Z image with small X and Y and check that the resulting `.zarray` looks good for achieving that chunk size (with z > 1, middle number of "chunks" list, also note dtype) and that the image still views just fine.

In review, going separately by commit or ignoring whitespace with `w=1` may help.