### PR TITLE
Internal refactoring of microservice dispatch.

### DIFF
--- a/src/main/java/org/openmicroscopy/ms/zarr/HttpHandler.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/HttpHandler.java
@@ -19,15 +19,13 @@
 
 package org.openmicroscopy.ms.zarr;
 
-import io.vertx.core.Handler;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 
 /**
  * Instances can respond to HTTP requests.
  * @author m.t.b.carroll@dundee.ac.uk
  */
-public interface HttpHandler extends Handler<RoutingContext> {
+public interface HttpHandler {
 
     /**
      * Add this instance as GET handler for the API paths.

--- a/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package org.openmicroscopy.ms.zarr;
 
 import ome.io.nio.PixelsService;

--- a/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
@@ -3,10 +3,10 @@ package org.openmicroscopy.ms.zarr;
 import ome.io.nio.PixelsService;
 import ome.model.core.Pixels;
 
-import org.hibernate.Query;
+import java.util.function.Function;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,36 +28,46 @@ class OmeroDao {
     }
 
     /**
+     * Provide a Hibernate session to a means of getting data from it.
+     * @param <X> the type of data to be gotten
+     * @param getter a getter for the data
+     * @return the sought data
+     */
+    private <X> X withSession(Function<Session, X> getter) {
+        Session session = null;
+        try {
+            session = sessionFactory.openSession();
+            session.setDefaultReadOnly(true);
+            return getter.apply(session);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    /**
      * Get a pixels instance that can be used with {@link PixelsService#getPixelBuffer(Pixels, boolean)}.
      * Includes extra {@code JOIN}s for {@link RequestHandlerForImage}.
      * @param imageId the ID of an image
      * @return that image's pixels instance, or {@code null} if one could not be found
      */
     Pixels getPixels(long imageId) {
-        Session session = null;
-        LOGGER.debug("fetch pixels for Image:{}", imageId);
-        try {
-            session = sessionFactory.openSession();
-            session.setDefaultReadOnly(true);
-            final Query query = session.createQuery(
-                    "SELECT p FROM Pixels AS p " +
-                    "JOIN FETCH p.pixelsType " +
-                    "LEFT OUTER JOIN FETCH p.channels AS c " +
-                    "LEFT OUTER JOIN FETCH p.image AS i " +
-                    "LEFT OUTER JOIN FETCH p.settings AS r " +
-                    "LEFT OUTER JOIN FETCH c.logicalChannel " +
-                    "LEFT OUTER JOIN FETCH c.statsInfo " +
-                    "LEFT OUTER JOIN FETCH r.model " +
-                    "LEFT OUTER JOIN FETCH r.waveRendering AS cb " +
-                    "LEFT OUTER JOIN FETCH cb.family " +
-                    "LEFT OUTER JOIN FETCH cb.spatialDomainEnhancement " +
-                    "WHERE i.id = ?");
-            query.setParameter(0, imageId);
-            return (Pixels) query.uniqueResult();
-        } finally {
-            if (session != null) {
-                session.close();
-            }
-        }
+        LOGGER.debug("fetch Pixels for Image:{}", imageId);
+        final String hql =
+                "SELECT p FROM Pixels AS p " +
+                "JOIN FETCH p.pixelsType " +
+                "LEFT OUTER JOIN FETCH p.channels AS c " +
+                "LEFT OUTER JOIN FETCH p.image AS i " +
+                "LEFT OUTER JOIN FETCH p.settings AS r " +
+                "LEFT OUTER JOIN FETCH c.logicalChannel " +
+                "LEFT OUTER JOIN FETCH c.statsInfo " +
+                "LEFT OUTER JOIN FETCH r.model " +
+                "LEFT OUTER JOIN FETCH r.waveRendering AS cb " +
+                "LEFT OUTER JOIN FETCH cb.family " +
+                "LEFT OUTER JOIN FETCH cb.spatialDomainEnhancement " +
+                "WHERE i.id = ?";
+        return withSession(session ->
+            (Pixels) session.createQuery(hql).setParameter(0, imageId).uniqueResult());
     }
 }

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -287,6 +287,9 @@ public class RequestHandlerForImage implements HttpHandler {
                     fail(response, 400, "failed to parse integer");
                 } catch (IllegalArgumentException iae) {
                     fail(response, 404, "path specifies unknown form of query parameters");
+                } catch (Throwable t) {
+                    LOGGER.warn("unexpected failure handling path: {}", requestPath, t);
+                    throw t;
                 }
             }
         });

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -53,6 +53,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -266,18 +267,17 @@ public class RequestHandlerForImage implements HttpHandler {
      * @param pattern a regular expression defining the paths that should be handled
      * @param handler the handler for the given paths
      */
-    private void handleFor(Router router, Pattern pattern, BiConsumer<HttpServerResponse, String> handler) {
+    private void handleFor(Router router, Pattern pattern, Consumer<HttpServerRequest> handler) {
         router.getWithRegex(pattern.pattern()).handler(new Handler<RoutingContext>() {
             @Override
             public void handle(RoutingContext context) {
-                final HttpServerResponse response = context.response();
-                final String path = context.request().path();
+                final HttpServerRequest request = context.request();
                 try {
-                    handler.accept(response, path);
+                    handler.accept(request);
                 } catch (NumberFormatException nfe) {
-                    fail(response, 400, "failed to parse integer");
+                    fail(request.response(), 400, "failed to parse integer");
                 } catch (IllegalArgumentException iae) {
-                    fail(response, 404, "path specifies unknown form of query parameters");
+                    fail(request.response(), 404, "path specifies unknown form of query parameters");
                 }
             }
         });
@@ -425,11 +425,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for the image directory.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnImageDirectory(HttpServerResponse response, String path) {
+    private void returnImageDirectory(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForImageDir.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -452,11 +453,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for the group directory in flattened mode.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnGroupDirectoryFlattened(HttpServerResponse response, String path) {
+    private void returnGroupDirectoryFlattened(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForGroupDir.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -486,10 +488,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for the group directory in nested mode.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnGroupDirectoryNested(HttpServerResponse response, String path) {
+    private void returnGroupDirectoryNested(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
+        /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForGroupDir.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -499,10 +503,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for the chunk directory in nested mode.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnChunkDirectory(HttpServerResponse response, String path) {
+    private void returnChunkDirectory(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
+        /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForChunkDir.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -572,11 +578,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for {@code .zgroup}.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnGroup(HttpServerResponse response, String path) {
+    private void returnGroup(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForGroup.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -675,11 +682,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for {@code .zattrs}.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnAttrs(HttpServerResponse response, String path) {
+    private void returnAttrs(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForAttrs.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -738,11 +746,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for {@code .zarray}.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnArray(HttpServerResponse response, String path) {
+    private void returnArray(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForArray.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));
@@ -795,11 +804,12 @@ public class RequestHandlerForImage implements HttpHandler {
 
     /**
      * Handle a request for a chunk of the pixel data.
-     * @param response the HTTP server response to populate
-     * @param path the path suffix from the HTTP request, specifying the query parameters
+     * @param request the HTTP server request to handle
      */
-    private void returnChunk(HttpServerResponse response, String path) {
+    private void returnChunk(HttpServerRequest request) {
+        final HttpServerResponse response = request.response();
         /* parse parameters from path */
+        final String path = request.path();
         final Matcher matcher = patternForChunk.matcher(path);
         matcher.matches();
         final long imageId = Long.parseLong(matcher.group(1));

--- a/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/PixelBufferCacheTest.java
@@ -81,6 +81,7 @@ public class PixelBufferCacheTest {
     public void mockSetup() {
         MockitoAnnotations.initMocks(this);
         Mockito.when(query.uniqueResult()).thenReturn(new Pixels());
+        Mockito.when(query.setParameter(Mockito.eq(0), Mockito.anyLong())).thenReturn(query);
         Mockito.when(sessionMock.createQuery(Mockito.anyString())).thenReturn(query);
         Mockito.when(sessionFactoryMock.openSession()).thenReturn(sessionMock);
         Mockito.when(pixelsServiceMock.getPixelBuffer(Mockito.any(Pixels.class), Mockito.eq(false))).thenAnswer(

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -52,7 +52,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;

--- a/src/test/java/org/openmicroscopy/ms/zarr/stub/RouteBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/stub/RouteBase.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.stub;
+
+import java.util.List;
+import java.util.Set;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A base class for implementing fake routes.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.5
+ */
+public abstract class RouteBase implements Route {
+
+    @Override
+    public Route method(HttpMethod method) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route path(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route pathRegex(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route produces(String contentType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route consumes(String contentType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route order(int order) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route last() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route handler(Handler<RoutingContext> requestHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route blockingHandler(Handler<RoutingContext> requestHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route subRouter(Router subRouter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route failureHandler(Handler<RoutingContext> failureHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route disable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route enable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route useNormalisedPath(boolean useNormalisedPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable String getPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRegexPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<HttpMethod> methods() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route setRegexGroupsNames(List<String> groups) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/stub/RouterFake.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/stub/RouterFake.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.stub;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+/**
+ * A fake router allowing unit tests to verify the handling of mock HTTP requests.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.5
+ */
+public class RouterFake implements Router {
+
+    private final Map<String, Handler<RoutingContext>> routes = new LinkedHashMap<>();
+
+    @Override
+    public Route getWithRegex(String regex) {
+        if (routes.containsKey(regex)) {
+            throw new IllegalArgumentException("route already exists");
+        } else {
+            routes.put(regex, null);
+        }
+        return new RouteBase() {
+            @Override
+            public Route handler(Handler<RoutingContext> requestHandler) {
+                routes.put(regex, requestHandler);
+                return this;
+            }
+        };
+    }
+
+    @Override
+    public void handle(HttpServerRequest httpRequest) {
+        for (final Map.Entry<String, Handler<RoutingContext>> route : routes.entrySet()) {
+            if (Pattern.matches(route.getKey(), httpRequest.path())) {
+                final RoutingContext context = Mockito.mock(RoutingContext.class);
+                Mockito.when(context.request()).thenReturn(httpRequest);
+                route.getValue().handle(context);
+                return;
+            }
+        }
+        Assertions.fail("HTTP request path is unhandled: " + httpRequest.path());
+    }
+
+    /* All other methods simply throw. */
+
+    @Override
+    public Route route() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route route(HttpMethod method, String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route route(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route routeWithRegex(HttpMethod method, String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route routeWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route get() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route get(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route head() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route head(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route headWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route options() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route options(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route optionsWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route put() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route put(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route putWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route post() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route post(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route postWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route delete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route delete(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route deleteWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route trace() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route trace(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route traceWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route connect() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route connect(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route connectWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route patch() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route patch(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Route patchWithRegex(String regex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Route> getRoutes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Router clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Router mountSubRouter(String mountPoint, Router subRouter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Router exceptionHandler(@Nullable Handler<Throwable> exceptionHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void handleContext(RoutingContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void handleFailure(RoutingContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Router modifiedHandler(Handler<Router> handler) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/stub/RoutingContextFake.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/stub/RoutingContextFake.java
@@ -19,252 +19,302 @@
 
 package org.openmicroscopy.ms.zarr.stub;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.Cookie;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.Locale;
+import io.vertx.ext.web.ParsedHeaderValues;
 import io.vertx.ext.web.Route;
-import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-
-import org.junit.jupiter.api.Assertions;
+import io.vertx.ext.web.Session;
 
 /**
- * A fake router allowing unit tests to verify the handling of mock HTTP requests.
+ * A fake routing context allowing unit tests to verify the handling of mock HTTP requests.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since v0.1.5
  */
-public class RouterFake implements Router {
+public class RoutingContextFake implements RoutingContext {
 
-    private final Map<String, Handler<RoutingContext>> routes = new LinkedHashMap<>();
+    private final HttpServerRequest request;
 
-    @Override
-    public Route getWithRegex(String regex) {
-        if (routes.containsKey(regex)) {
-            throw new IllegalArgumentException("route already exists");
-        } else {
-            routes.put(regex, null);
-        }
-        return new RouteBase() {
-            @Override
-            public Route handler(Handler<RoutingContext> requestHandler) {
-                routes.put(regex, requestHandler);
-                return this;
-            }
-        };
+    public RoutingContextFake(HttpServerRequest request) {
+        this.request = request;
     }
 
     @Override
-    public void handle(HttpServerRequest httpRequest) {
-        for (final Map.Entry<String, Handler<RoutingContext>> route : routes.entrySet()) {
-            if (Pattern.matches(route.getKey(), httpRequest.path())) {
-                final RoutingContext routingContext = new RoutingContextFake(httpRequest);
-                route.getValue().handle(routingContext);
-                return;
-            }
-        }
-        Assertions.fail("HTTP request path is unhandled: " + httpRequest.path());
+    public HttpServerRequest request() {
+        return request;
+    }
+
+    @Override
+    public HttpServerResponse response() {
+        return request.response();
     }
 
     /* All other methods simply throw. */
 
     @Override
-    public Route route() {
+    public void next() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route route(HttpMethod method, String path) {
+    public void fail(int statusCode) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route route(String path) {
+    public void fail(Throwable throwable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route routeWithRegex(HttpMethod method, String regex) {
+    public void fail(int statusCode, Throwable throwable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route routeWithRegex(String regex) {
+    public RoutingContext put(String key, Object obj) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route get() {
+    public <T> T get(String key) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route get(String path) {
+    public <T> T remove(String key) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route head() {
+    public Map<String, Object> data() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route head(String path) {
+    public Vertx vertx() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route headWithRegex(String regex) {
+    public @Nullable String mountPoint() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route options() {
+    public Route currentRoute() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route options(String path) {
+    public String normalisedPath() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route optionsWithRegex(String regex) {
+    public @Nullable Cookie getCookie(String name) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route put() {
+    public RoutingContext addCookie(io.vertx.core.http.Cookie cookie) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route put(String path) {
+    public RoutingContext addCookie(Cookie cookie) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route putWithRegex(String regex) {
+    public @Nullable Cookie removeCookie(String name, boolean invalidate) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route post() {
+    public int cookieCount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route post(String path) {
+    public Set<Cookie> cookies() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route postWithRegex(String regex) {
+    public Map<String, io.vertx.core.http.Cookie> cookieMap() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route delete() {
+    public @Nullable String getBodyAsString() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route delete(String path) {
+    public @Nullable String getBodyAsString(String encoding) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route deleteWithRegex(String regex) {
+    public @Nullable JsonObject getBodyAsJson() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route trace() {
+    public @Nullable JsonArray getBodyAsJsonArray() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route trace(String path) {
+    public @Nullable Buffer getBody() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route traceWithRegex(String regex) {
+    public Set<FileUpload> fileUploads() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route connect() {
+    public @Nullable Session session() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route connect(String path) {
+    public boolean isSessionAccessed() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route connectWithRegex(String regex) {
+    public @Nullable User user() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route patch() {
+    public @Nullable Throwable failure() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route patch(String path) {
+    public int statusCode() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Route patchWithRegex(String regex) {
+    public @Nullable String getAcceptableContentType() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<Route> getRoutes() {
+    public ParsedHeaderValues parsedHeaders() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Router clear() {
+    public int addHeadersEndHandler(Handler<Void> handler) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Router mountSubRouter(String mountPoint, Router subRouter) {
+    public boolean removeHeadersEndHandler(int handlerID) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Router exceptionHandler(@Nullable Handler<Throwable> exceptionHandler) {
+    public int addBodyEndHandler(Handler<Void> handler) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler) {
+    public boolean removeBodyEndHandler(int handlerID) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void handleContext(RoutingContext context) {
+    public int addEndHandler(Handler<AsyncResult<Void>> handler) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void handleFailure(RoutingContext context) {
+    public boolean removeEndHandler(int handlerID) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Router modifiedHandler(Handler<Router> handler) {
+    public boolean failed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBody(Buffer body) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSession(Session session) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setUser(User user) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clearUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAcceptableContentType(@Nullable String contentType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reroute(HttpMethod method, String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Locale> acceptableLocales() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> pathParams() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable String pathParam(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MultiMap queryParams() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> queryParam(String name) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Previously the microservice was needlessly repeating some of Vert.x's work in matching URI patterns against corresponding behavior. This PR bears general factoring to make it easier to add further methods: the masks work is building on this branch. There should be no outward changes in behavior.