### PR TITLE
initial provision of masks by microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ In addition to your usual OMERO.server configuration, the microservice's
 : for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
 
 `omero.ms.zarr.mask.split.enable`
-: if masks split by ROI should be offered; default is `true`, can be set to `false`
+: if masks split by ROI should be offered; default is `false`, can be set to `true`
 
 `omero.ms.zarr.mask.overlap.color`
 : color to use for overlapping region in labeled masks, as a signed integer as in the OME Model; not set by default
 
 `omero.ms.zarr.mask.overlap.value`
-: value to set for overlapping region in labeled masks, as a signed integer or "HIGHEST" or "LOWEST"; not set by default, thus disabling overlap support
+: value to set for overlapping region in labeled masks, as a signed integer or "LOWEST" or "HIGHEST" (the default); setting to null disables overlap support
 
 `omero.ms.zarr.mask-cache.size`
 : mask cache size in megabytes, default 250

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In addition to your usual OMERO.server configuration, the microservice's
 : zlib compression level for chunks, default 6
 
 `omero.ms.zarr.folder.layout`
-: for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
+: for directory listings, default `flattened` chunks, can be `nested`; `none` disables directory listings
 
 `omero.ms.zarr.mask.split.enable`
 : if masks split by ROI should be offered; default is `false`, can be set to `true`

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ In addition to your usual OMERO.server configuration, the microservice's
 `omero.ms.zarr.folder.layout`
 : for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
 
+`omero.ms.zarr.mask-cache.size`
+: mask cache size in megabytes, default 250
+
 `omero.ms.zarr.net.path.image`
 : URI template path for getting image data, default `/image/{image}.zarr/` where `{image}` signifies the image ID and is mandatory
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ In addition to your usual OMERO.server configuration, the microservice's
 `omero.ms.zarr.folder.layout`
 : for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
 
+`omero.ms.zarr.mask.split.enable`
+: if masks split by ROI should be offered; default is `true`, can be set to `false`
+
+`omero.ms.zarr.mask.overlap.color`
+: color to use for overlapping region in labeled masks, as a signed integer as in the OME Model; not set by default
+
 `omero.ms.zarr.mask.overlap.value`
-: value to set for overlapping region in labeled masks; not set by default, thus disabling overlap support
+: value to set for overlapping region in labeled masks, as a signed integer or "HIGHEST" or "LOWEST"; not set by default, thus disabling overlap support
 
 `omero.ms.zarr.mask-cache.size`
 : mask cache size in megabytes, default 250

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ In addition to your usual OMERO.server configuration, the microservice's
 `omero.ms.zarr.folder.layout`
 : for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
 
+`omero.ms.zarr.mask.overlap.value`
+: value to set for overlapping region in labeled masks; not set by default, thus disabling overlap support
+
 `omero.ms.zarr.mask-cache.size`
 : mask cache size in megabytes, default 250
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
@@ -65,12 +65,12 @@ public class Configuration {
     private List<Character> chunkSizeAdjust = ImmutableList.of('X', 'Y', 'Z');
     private int chunkSizeMin = 0x100000;
     private int zlibLevel = 6;
-    private Boolean foldersNested = true;
+    private Boolean foldersNested = false;
     private String netPath = getRegexForNetPath("/image/" + PLACEHOLDER_IMAGE_ID + ".zarr/");
     private int netPort = 8080;
-    private boolean maskSplitEnable = true;
+    private boolean maskSplitEnable = false;
     private Integer maskOverlapColor = null;
-    private Long maskOverlapValue = null;
+    private Long maskOverlapValue = Long.MAX_VALUE;
 
     /**
      * Convert the given URI path to a regular expression in which {@link #PLACEHOLDER_IMAGE_ID} matches the image ID.

--- a/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
@@ -53,6 +53,7 @@ public class Configuration {
     public final static String CONF_COMPRESS_ZLIB_LEVEL = "compress.zlib.level";
     public final static String CONF_FOLDER_LAYOUT = "folder.layout";
     public final static String CONF_MASK_CACHE_SIZE = "mask-cache.size";
+    public final static String CONF_MASK_OVERLAP_VALUE = "mask.overlap.value";
     public final static String CONF_NET_PATH_IMAGE = "net.path.image";
     public final static String CONF_NET_PORT = "net.port";
 
@@ -65,6 +66,7 @@ public class Configuration {
     private Boolean foldersNested = true;
     private String netPath = getRegexForNetPath("/image/" + PLACEHOLDER_IMAGE_ID + ".zarr/");
     private int netPort = 8080;
+    private Long maskOverlapValue = null;
 
     /**
      * Convert the given URI path to a regular expression in which {@link #PLACEHOLDER_IMAGE_ID} matches the image ID.
@@ -123,6 +125,7 @@ public class Configuration {
         final String zlibLevel = configuration.get(CONF_COMPRESS_ZLIB_LEVEL);
         final String folderLayout = configuration.get(CONF_FOLDER_LAYOUT);
         final String maskCacheSize = configuration.get(CONF_MASK_CACHE_SIZE);
+        final String maskOverlapValue = configuration.get(CONF_MASK_OVERLAP_VALUE);
         final String netPath = configuration.get(CONF_NET_PATH_IMAGE);
         final String netPort = configuration.get(CONF_NET_PORT);
 
@@ -208,6 +211,16 @@ public class Configuration {
             }
         }
 
+        if (maskOverlapValue != null) {
+            try {
+                this.maskOverlapValue = Long.parseLong(maskOverlapValue);
+            } catch (NumberFormatException nfe) {
+                final String message = "mask overlap value must be an integer, not " + maskOverlapValue;
+                LOGGER.error(message);
+                throw new IllegalArgumentException(message);
+            }
+        }
+
         if (netPath != null) {
             if (netPath.indexOf('\\') == -1) {
                 if (netPath.contains(PLACEHOLDER_IMAGE_ID)) {
@@ -281,6 +294,13 @@ public class Configuration {
      */
     public long getMaskCacheSize() {
         return maskCacheSize;
+    }
+
+    /**
+     * @return the configured mask overlap value ({@code null} for no overlaps)
+     */
+    public Long getMaskOverlapValue() {
+        return maskOverlapValue;
     }
 
     /**

--- a/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
@@ -52,11 +52,13 @@ public class Configuration {
     public final static String CONF_CHUNK_SIZE_MIN = "chunk.size.min";
     public final static String CONF_COMPRESS_ZLIB_LEVEL = "compress.zlib.level";
     public final static String CONF_FOLDER_LAYOUT = "folder.layout";
+    public final static String CONF_MASK_CACHE_SIZE = "mask-cache.size";
     public final static String CONF_NET_PATH_IMAGE = "net.path.image";
     public final static String CONF_NET_PORT = "net.port";
 
     /* Configuration initialized to default values. */
-    private int cacheSize = 16;
+    private int bufferCacheSize = 16;
+    private long maskCacheSize = 250 * 1000000L;
     private List<Character> chunkSizeAdjust = ImmutableList.of('X', 'Y', 'Z');
     private int chunkSizeMin = 0x100000;
     private int zlibLevel = 6;
@@ -115,19 +117,20 @@ public class Configuration {
      * @param configuration the configuration keys and values to apply over the current state.
      */
     private void setConfiguration(Map<String, String> configuration) {
-        final String cacheSize = configuration.get(CONF_BUFFER_CACHE_SIZE);
+        final String bufferCacheSize = configuration.get(CONF_BUFFER_CACHE_SIZE);
         final String chunkSizeAdjust = configuration.get(CONF_CHUNK_SIZE_ADJUST);
         final String chunkSizeMin = configuration.get(CONF_CHUNK_SIZE_MIN);
         final String zlibLevel = configuration.get(CONF_COMPRESS_ZLIB_LEVEL);
         final String folderLayout = configuration.get(CONF_FOLDER_LAYOUT);
+        final String maskCacheSize = configuration.get(CONF_MASK_CACHE_SIZE);
         final String netPath = configuration.get(CONF_NET_PATH_IMAGE);
         final String netPort = configuration.get(CONF_NET_PORT);
 
-        if (cacheSize != null) {
+        if (bufferCacheSize != null) {
             try {
-                this.cacheSize = Integer.parseInt(cacheSize);
+                this.bufferCacheSize = Integer.parseInt(bufferCacheSize);
             } catch (NumberFormatException nfe) {
-                final String message = "buffer cache size must be an integer, not " + cacheSize;
+                final String message = "buffer cache size must be an integer, not " + bufferCacheSize;
                 LOGGER.error(message);
                 throw new IllegalArgumentException(message);
             }
@@ -195,6 +198,16 @@ public class Configuration {
             }
         }
 
+        if (maskCacheSize != null) {
+            try {
+                this.maskCacheSize = Long.parseLong(maskCacheSize) * 1000000L;
+            } catch (NumberFormatException nfe) {
+                final String message = "mask cache size must be an integer, not " + maskCacheSize;
+                LOGGER.error(message);
+                throw new IllegalArgumentException(message);
+            }
+        }
+
         if (netPath != null) {
             if (netPath.indexOf('\\') == -1) {
                 if (netPath.contains(PLACEHOLDER_IMAGE_ID)) {
@@ -232,7 +245,7 @@ public class Configuration {
      * @return the configured pixel buffer cache size
      */
     public int getBufferCacheSize() {
-        return cacheSize;
+        return bufferCacheSize;
     }
 
     /**
@@ -261,6 +274,13 @@ public class Configuration {
      */
     public Boolean getFoldersNested() {
         return foldersNested;
+    }
+
+    /**
+     * @return the configured mask cache size
+     */
+    public long getMaskCacheSize() {
+        return maskCacheSize;
     }
 
     /**

--- a/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
@@ -114,6 +114,15 @@ class OmeroDao {
             ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, imageId).iterate()));
     }
 
+    SortedSet<Long> getRoiIdsWithMaskOfImage(long imageId) {
+        LOGGER.debug("fetch Roi IDs for Image:{} where each Roi has a Mask", imageId);
+        final String hql =
+                "SELECT DISTINCT roi.id FROM Mask " +
+                "WHERE roi.image.id = ?";
+        return withSession(session ->
+            ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, imageId).iterate()));
+    }
+
     long getMaskCountOfRoi(long roiId) {
         LOGGER.debug("fetch Mask count for Roi:{}", roiId);
         final String hql =

--- a/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
@@ -96,6 +96,10 @@ class OmeroDao {
             (Pixels) session.createQuery(hql).setParameter(0, imageId).uniqueResult());
     }
 
+    /**
+     * @param imageId the ID of an image
+     * @return how many Rois the image has
+     */
     long getRoiCountOfImage(long imageId) {
         LOGGER.debug("fetch Roi count for Image:{}", imageId);
         final String hql =
@@ -105,6 +109,10 @@ class OmeroDao {
             (Long) session.createQuery(hql).setParameter(0, imageId).uniqueResult());
     }
 
+    /**
+     * @param imageId the ID of an image
+     * @return the IDs of the image's Rois
+     */
     SortedSet<Long> getRoiIdsOfImage(long imageId) {
         LOGGER.debug("fetch Roi IDs for Image:{}", imageId);
         final String hql =
@@ -114,6 +122,10 @@ class OmeroDao {
             ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, imageId).iterate()));
     }
 
+    /**
+     * @param imageId the ID of an image
+     * @return the IDs of the image's Rois, limited to those that have a Mask
+     */
     SortedSet<Long> getRoiIdsWithMaskOfImage(long imageId) {
         LOGGER.debug("fetch Roi IDs for Image:{} where each Roi has a Mask", imageId);
         final String hql =
@@ -123,6 +135,10 @@ class OmeroDao {
             ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, imageId).iterate()));
     }
 
+    /**
+     * @param roiId the ID of a Roi
+     * @return how many masks the Roi has
+     */
     long getMaskCountOfRoi(long roiId) {
         LOGGER.debug("fetch Mask count for Roi:{}", roiId);
         final String hql =
@@ -132,6 +148,10 @@ class OmeroDao {
             (Long) session.createQuery(hql).setParameter(0, roiId).uniqueResult());
     }
 
+    /**
+     * @param roiId the ID of a Roi
+     * @return the IDs of the Roi's Masks
+     */
     SortedSet<Long> getMaskIdsOfRoi(long roiId) {
         LOGGER.debug("fetch Mask IDs for Roi:{}", roiId);
         final String hql =
@@ -141,12 +161,20 @@ class OmeroDao {
             ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, roiId).iterate()));
     }
 
+    /**
+     * @param roiId the ID of a Roi
+     * @return the Roi
+     */
     Roi getRoi(long roiId) {
         LOGGER.debug("fetch Roi:{}", roiId);
         return withSession(session ->
             (Roi) session.get(Roi.class, roiId));
     }
 
+    /**
+     * @param maskId the ID of a Mask
+     * @return the Mask
+     */
     Mask getMask(long maskId) {
         LOGGER.debug("fetch Mask:{}", maskId);
         return withSession(session ->

--- a/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/OmeroDao.java
@@ -21,8 +21,14 @@ package org.openmicroscopy.ms.zarr;
 
 import ome.io.nio.PixelsService;
 import ome.model.core.Pixels;
+import ome.model.roi.Mask;
+import ome.model.roi.Roi;
 
+import java.util.Iterator;
+import java.util.SortedSet;
 import java.util.function.Function;
+
+import com.google.common.collect.ImmutableSortedSet;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -88,5 +94,53 @@ class OmeroDao {
                 "WHERE i.id = ?";
         return withSession(session ->
             (Pixels) session.createQuery(hql).setParameter(0, imageId).uniqueResult());
+    }
+
+    long getRoiCountOfImage(long imageId) {
+        LOGGER.debug("fetch Roi count for Image:{}", imageId);
+        final String hql =
+                "SELECT COUNT(id) FROM Roi " +
+                "WHERE image.id = ?";
+        return withSession(session ->
+            (Long) session.createQuery(hql).setParameter(0, imageId).uniqueResult());
+    }
+
+    SortedSet<Long> getRoiIdsOfImage(long imageId) {
+        LOGGER.debug("fetch Roi IDs for Image:{}", imageId);
+        final String hql =
+                "SELECT id FROM Roi " +
+                "WHERE image.id = ?";
+        return withSession(session ->
+            ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, imageId).iterate()));
+    }
+
+    long getMaskCountOfRoi(long roiId) {
+        LOGGER.debug("fetch Mask count for Roi:{}", roiId);
+        final String hql =
+                "SELECT COUNT(id) FROM Mask " +
+                "WHERE roi.id = ?";
+        return withSession(session ->
+            (Long) session.createQuery(hql).setParameter(0, roiId).uniqueResult());
+    }
+
+    SortedSet<Long> getMaskIdsOfRoi(long roiId) {
+        LOGGER.debug("fetch Mask IDs for Roi:{}", roiId);
+        final String hql =
+                "SELECT id FROM Mask " +
+                "WHERE roi.id = ?";
+        return withSession(session ->
+            ImmutableSortedSet.copyOf((Iterator<Long>) session.createQuery(hql).setParameter(0, roiId).iterate()));
+    }
+
+    Roi getRoi(long roiId) {
+        LOGGER.debug("fetch Roi:{}", roiId);
+        return withSession(session ->
+            (Roi) session.get(Roi.class, roiId));
+    }
+
+    Mask getMask(long maskId) {
+        LOGGER.debug("fetch Mask:{}", maskId);
+        return withSession(session ->
+            (Mask) session.get(Mask.class, maskId));
     }
 }

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1247,56 +1247,56 @@ public class RequestHandlerForImage implements HttpHandler {
             labeledMasks.put(roiId, imageMask);
         }
         if (maskOverlapValue == null) {
-        /* Check that there are no overlaps. */
-        for (final Map.Entry<Long, Bitmask> labeledMask1 : labeledMasks.entrySet()) {
-            final long label1 = labeledMask1.getKey();
-            final Bitmask mask1 = labeledMask1.getValue();
-            if (mask1 instanceof ImageMask) {
-                final ImageMask imageMask1 = (ImageMask) mask1;
-                for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
-                    final long label2 = labeledMask2.getKey();
-                    final Bitmask mask2 = labeledMask2.getValue();
-                    if (label1 < label2) {
-                        if (mask2 instanceof ImageMask) {
-                            final ImageMask imageMask2 = (ImageMask) mask2;
-                            if (imageMask2.isOverlap(imageMask1)) {
-                                return null;
+            /* Check that there are no overlaps. */
+            for (final Map.Entry<Long, Bitmask> labeledMask1 : labeledMasks.entrySet()) {
+                final long label1 = labeledMask1.getKey();
+                final Bitmask mask1 = labeledMask1.getValue();
+                if (mask1 instanceof ImageMask) {
+                    final ImageMask imageMask1 = (ImageMask) mask1;
+                    for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
+                        final long label2 = labeledMask2.getKey();
+                        final Bitmask mask2 = labeledMask2.getValue();
+                        if (label1 < label2) {
+                            if (mask2 instanceof ImageMask) {
+                                final ImageMask imageMask2 = (ImageMask) mask2;
+                                if (imageMask2.isOverlap(imageMask1)) {
+                                    return null;
+                                }
+                            } else if (mask2 instanceof UnionMask) {
+                                final UnionMask unionMask2 = (UnionMask) mask2;
+                                if (unionMask2.isOverlap(imageMask1)) {
+                                    return null;
+                                }
+                            } else {
+                                throw new IllegalStateException();
                             }
-                        } else if (mask2 instanceof UnionMask) {
-                            final UnionMask unionMask2 = (UnionMask) mask2;
-                            if (unionMask2.isOverlap(imageMask1)) {
-                                return null;
-                            }
-                        } else {
-                            throw new IllegalStateException();
                         }
                     }
-                }
-            } else if (mask1 instanceof UnionMask) {
-                final UnionMask unionMask1 = (UnionMask) mask1;
-                for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
-                    final long label2 = labeledMask2.getKey();
-                    final Bitmask mask2 = labeledMask2.getValue();
-                    if (label1 < label2) {
-                        if (mask2 instanceof ImageMask) {
-                            final ImageMask imageMask2 = (ImageMask) mask2;
-                            if (unionMask1.isOverlap(imageMask2)) {
-                                return null;
+                } else if (mask1 instanceof UnionMask) {
+                    final UnionMask unionMask1 = (UnionMask) mask1;
+                    for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
+                        final long label2 = labeledMask2.getKey();
+                        final Bitmask mask2 = labeledMask2.getValue();
+                        if (label1 < label2) {
+                            if (mask2 instanceof ImageMask) {
+                                final ImageMask imageMask2 = (ImageMask) mask2;
+                                if (unionMask1.isOverlap(imageMask2)) {
+                                    return null;
+                                }
+                            } else if (mask2 instanceof UnionMask) {
+                                final UnionMask unionMask2 = (UnionMask) mask2;
+                                if (unionMask1.isOverlap(unionMask2)) {
+                                    return null;
+                                }
+                            } else {
+                                throw new IllegalStateException();
                             }
-                        } else if (mask2 instanceof UnionMask) {
-                            final UnionMask unionMask2 = (UnionMask) mask2;
-                            if (unionMask1.isOverlap(unionMask2)) {
-                                return null;
-                            }
-                        } else {
-                            throw new IllegalStateException();
                         }
                     }
+                } else {
+                    throw new IllegalStateException();
                 }
-            } else {
-                throw new IllegalStateException();
             }
-        }
         }
         return labeledMasks;
     }

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1224,13 +1224,13 @@ public class RequestHandlerForImage implements HttpHandler {
         case 1:
             return getLabeledMasksForCache(imageId);
         default:
-        try {
-            final Optional<Map<Long, Bitmask>> labeledMasks = labeledMaskCache.get(imageId);
-            return labeledMasks.isPresent() ? labeledMasks.get() : null;
-        } catch (ExecutionException ee) {
-            LOGGER.warn("failed to get labeled masks for image {}", imageId, ee.getCause());
-            return null;
-        }
+            try {
+                final Optional<Map<Long, Bitmask>> labeledMasks = labeledMaskCache.get(imageId);
+                return labeledMasks.isPresent() ? labeledMasks.get() : null;
+            } catch (ExecutionException ee) {
+                LOGGER.warn("failed to get labeled masks for image {}", imageId, ee.getCause());
+                return null;
+            }
         }
     }
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1426,7 +1426,7 @@ public class RequestHandlerForImage implements HttpHandler {
     /**
      * Constructs tiles on request.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since v0.1.6
+     * @since v0.1.7
      */
     private interface TileGetter {
         /**

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1214,10 +1214,7 @@ public class RequestHandlerForImage implements HttpHandler {
      * overlapping masks with {@link Configuration#CONF_MASK_OVERLAP_VALUE} not set
      */
     private Map<Long, Bitmask> getLabeledMasks(long imageId) {
-        final List<Long> roiIds = new ArrayList<>();
-        for (final long roiId : getRoiIdsWithMask(imageId)) {
-            roiIds.add(roiId);
-        }
+        final Collection<Long> roiIds = getRoiIdsWithMask(imageId);
         switch (roiIds.size()) {
         case 0:
             return null;

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -305,7 +305,6 @@ public class RequestHandlerForImage implements HttpHandler {
      * @return the cache
      */
     private LoadingCache<Long, Optional<Map<Long, Bitmask>>> buildLabeledMaskCache(long maximumWeight) {
-        LOGGER.info("weight is " + maximumWeight);
         return CacheBuilder.newBuilder()
                 .weigher(new Weigher<Long, Optional<Map<Long, Bitmask>>>() {
                     @Override

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1214,12 +1214,23 @@ public class RequestHandlerForImage implements HttpHandler {
      * overlapping masks with {@link Configuration#CONF_MASK_OVERLAP_VALUE} not set
      */
     private Map<Long, Bitmask> getLabeledMasks(long imageId) {
+        final List<Long> roiIds = new ArrayList<>();
+        for (final long roiId : getRoiIdsWithMask(imageId)) {
+            roiIds.add(roiId);
+        }
+        switch (roiIds.size()) {
+        case 0:
+            return null;
+        case 1:
+            return getLabeledMasksForCache(imageId);
+        default:
         try {
             final Optional<Map<Long, Bitmask>> labeledMasks = labeledMaskCache.get(imageId);
             return labeledMasks.isPresent() ? labeledMasks.get() : null;
         } catch (ExecutionException ee) {
             LOGGER.warn("failed to get labeled masks for image {}", imageId, ee.getCause());
             return null;
+        }
         }
     }
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -19,6 +19,10 @@
 
 package org.openmicroscopy.ms.zarr;
 
+import org.openmicroscopy.ms.zarr.mask.Bitmask;
+import org.openmicroscopy.ms.zarr.mask.ImageMask;
+import org.openmicroscopy.ms.zarr.mask.UnionMask;
+
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.model.core.Channel;
@@ -29,25 +33,39 @@ import ome.model.display.CodomainMapContext;
 import ome.model.display.RenderingDef;
 import ome.model.display.ReverseIntensityContext;
 import ome.model.enums.RenderingModel;
+import ome.model.roi.Roi;
 import ome.model.stats.StatsInfo;
 import ome.util.PixelData;
 
 import java.awt.Dimension;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.Deflater;
 
 import com.google.common.base.Joiner;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Weigher;
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -90,6 +108,7 @@ public class RequestHandlerForImage implements HttpHandler {
         int xTile, yTile, zTile;
 
         /**
+         * Construct the shape of image data.
          * @param buffer the pixel buffer from which to extract the dimensionality
          */
         DataShape(PixelBuffer buffer) {
@@ -99,7 +118,44 @@ public class RequestHandlerForImage implements HttpHandler {
             zSize = buffer.getSizeZ();
             tSize = buffer.getSizeT();
 
-            final Dimension tileSize = buffer.getTileSize();
+            byteWidth = buffer.getByteWidth();
+
+            applyTileSize(buffer.getTileSize());
+        }
+
+        /**
+         * Construct the shape of a mask.
+         * @param buffer the pixel buffer from which to extract the dimensionality
+         * @param mask the mask to use to limit dimensionality based on {@link Bitmask#isSignificant(char)}
+         * @param byteWidth the applicable byte width, typically {@code 1} for a split mask
+         */
+        DataShape(PixelBuffer buffer, Bitmask mask, int byteWidth) {
+            this(buffer, Collections.singleton(mask), byteWidth);
+        }
+
+        /**
+         * Construct the shape of a mask.
+         * @param buffer the pixel buffer from which to extract the dimensionality
+         * @param masks the masks to use to limit dimensionality based on {@link Bitmask#isSignificant(char)}
+         * @param byteWidth the applicable byte width, typically {@link Long#BYTES} for a labeled mask
+         */
+        DataShape(PixelBuffer buffer, Collection<Bitmask> masks, int byteWidth) {
+            xSize = buffer.getSizeX();
+            ySize = buffer.getSizeY();
+            cSize = masks.stream().anyMatch(mask -> mask.isSignificant('C')) ? buffer.getSizeC() : 1;
+            zSize = masks.stream().anyMatch(mask -> mask.isSignificant('Z')) ? buffer.getSizeZ() : 1;
+            tSize = masks.stream().anyMatch(mask -> mask.isSignificant('T')) ? buffer.getSizeT() : 1;
+
+            this.byteWidth = byteWidth;
+
+            applyTileSize(buffer.getTileSize());
+        }
+
+        /**
+         * Helper for constructors.
+         * @param tileSize the tile size to set for this shape
+         */
+        private void applyTileSize(Dimension tileSize) {
             if (tileSize == null) {
                 xTile = xSize;
                 yTile = ySize;
@@ -108,8 +164,6 @@ public class RequestHandlerForImage implements HttpHandler {
                 yTile = tileSize.height;
             }
             zTile = 1;
-
-            byteWidth = buffer.getByteWidth();
         }
 
         /**
@@ -216,13 +270,57 @@ public class RequestHandlerForImage implements HttpHandler {
     private final Boolean foldersNested;
 
     private final Pattern patternForImageDir;
-    private final Pattern patternForGroupDir;
-    private final Pattern patternForChunkDir;
+    private final Pattern patternForImageGroupDir;
+    private final Pattern patternForImageChunkDir;
+    private final Pattern patternForImageMasksDir;
+    private final Pattern patternForMaskDir;
+    private final Pattern patternForMaskChunkDir;
+    private final Pattern patternForMaskLabeledDir;
+    private final Pattern patternForMaskLabeledChunkDir;
 
-    private final Pattern patternForGroup;
-    private final Pattern patternForAttrs;
-    private final Pattern patternForArray;
-    private final Pattern patternForChunk;
+    private final Pattern patternForImageGroup;
+    private final Pattern patternForImageAttrs;
+    private final Pattern patternForImageMasksGroup;
+    private final Pattern patternForImageMasksAttrs;
+    private final Pattern patternForMaskAttrs;
+    private final Pattern patternForMaskLabeledAttrs;
+    private final Pattern patternForImageArray;
+    private final Pattern patternForMaskArray;
+    private final Pattern patternForMaskLabeledArray;
+    private final Pattern patternForImageChunk;
+    private final Pattern patternForMaskChunk;
+    private final Pattern patternForMaskLabeledChunk;
+
+    /* Labeled masks may be expensive to construct so here they are cached. */
+    private final LoadingCache<Long, Optional<Map<Long, Bitmask>>> labeledMaskCache;
+
+    /**
+     * Build the cache for labeled masks.
+     * @param maximumWeight the maximum weight to set for the cache
+     * @return the cache
+     */
+    private LoadingCache<Long, Optional<Map<Long, Bitmask>>> buildLabeledMaskCache(long maximumWeight) {
+        LOGGER.info("weight is " + maximumWeight);
+        return CacheBuilder.newBuilder()
+                .weigher(new Weigher<Long, Optional<Map<Long, Bitmask>>>() {
+                    @Override
+                    public int weigh(Long imageId, Optional<Map<Long, Bitmask>> labeledMasks) {
+                        if (labeledMasks.isPresent()) {
+                            return labeledMasks.get().values().stream().map(Bitmask::size).reduce(0, Math::addExact);
+                        } else {
+                            return 0;
+                        }
+                    }
+                })
+                .maximumWeight(maximumWeight)
+                .expireAfterAccess(1, TimeUnit.MINUTES)
+                .build(new CacheLoader<Long, Optional<Map<Long, Bitmask>>>() {
+                    @Override
+                    public Optional<Map<Long, Bitmask>> load(Long key) {
+                        return Optional.ofNullable(getLabeledMasksForCache(key));
+                    }
+                });
+    }
 
     /**
      * Create the HTTP request handler.
@@ -246,17 +344,31 @@ public class RequestHandlerForImage implements HttpHandler {
         this.chunkSizeMin = configuration.getMinimumChunkSize();
         this.deflateLevel = configuration.getDeflateLevel();
         this.foldersNested = configuration.getFoldersNested();
+        this.labeledMaskCache = buildLabeledMaskCache(configuration.getMaskCacheSize());
 
         final String path = configuration.getPathRegex();
 
         this.patternForImageDir = Pattern.compile(path);
-        this.patternForGroupDir = Pattern.compile(path + "(\\d+)/");
-        this.patternForChunkDir = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)/");
+        this.patternForImageGroupDir = Pattern.compile(path + "(\\d+)/");
+        this.patternForImageChunkDir = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)/");
+        this.patternForImageMasksDir = Pattern.compile(path + "masks/");
+        this.patternForMaskDir = Pattern.compile(path + "masks/(\\d+)/");
+        this.patternForMaskChunkDir = Pattern.compile(path + "masks/(\\d+)/(\\d+([/.]\\d+)*)/");
+        this.patternForMaskLabeledDir = Pattern.compile(path + "masks/labell?ed/");
+        this.patternForMaskLabeledChunkDir = Pattern.compile(path + "masks/labell?ed/(\\d+([/.]\\d+)*)/");
 
-        this.patternForGroup = Pattern.compile(path + "\\.zgroup");
-        this.patternForAttrs = Pattern.compile(path + "\\.zattrs");
-        this.patternForArray = Pattern.compile(path + "(\\d+)/\\.zarray");
-        this.patternForChunk = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)");
+        this.patternForImageGroup = Pattern.compile(path + "\\.zgroup");
+        this.patternForImageAttrs = Pattern.compile(path + "\\.zattrs");
+        this.patternForImageMasksGroup = Pattern.compile(path + "masks/\\.zgroup");
+        this.patternForImageMasksAttrs = Pattern.compile(path + "masks/\\.zattrs");
+        this.patternForMaskAttrs = Pattern.compile(path + "masks/(\\d+)/\\.zattrs");
+        this.patternForMaskLabeledAttrs = Pattern.compile(path + "masks/labell?ed/\\.zattrs");
+        this.patternForImageArray = Pattern.compile(path + "(\\d+)/\\.zarray");
+        this.patternForMaskArray = Pattern.compile(path + "masks/(\\d+)/\\.zarray");
+        this.patternForMaskLabeledArray = Pattern.compile(path + "masks/labell?ed/\\.zarray");
+        this.patternForImageChunk = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)");
+        this.patternForMaskChunk = Pattern.compile(path + "masks/(\\d+)/(\\d+([/.]\\d+)*)");
+        this.patternForMaskLabeledChunk = Pattern.compile(path + "masks/labell?ed/(\\d+([/.]\\d+)*)");
     }
 
     /**
@@ -286,7 +398,7 @@ public class RequestHandlerForImage implements HttpHandler {
                 } catch (NumberFormatException nfe) {
                     fail(response, 400, "failed to parse integer");
                 } catch (IllegalArgumentException iae) {
-                    fail(response, 404, "path specifies unknown form of query parameters");
+                    fail(response, 404, iae.getMessage());
                 } catch (Throwable t) {
                     LOGGER.warn("unexpected failure handling path: {}", requestPath, t);
                     throw t;
@@ -301,16 +413,31 @@ public class RequestHandlerForImage implements HttpHandler {
         if (foldersNested != null) {
             handleFor(router, patternForImageDir, this::returnImageDirectory);
             if (foldersNested) {
-                handleFor(router, patternForGroupDir, this::returnGroupDirectoryNested);
-                handleFor(router, patternForChunkDir, this::returnChunkDirectory);
+                handleFor(router, patternForImageGroupDir, this::returnImageGroupDirectoryNested);
+                handleFor(router, patternForMaskDir, this::returnMaskDirectoryNested);
+                handleFor(router, patternForMaskLabeledDir, this::returnMaskLabeledDirectoryNested);
+                handleFor(router, patternForImageChunkDir, this::returnImageChunkDirectory);
+                handleFor(router, patternForMaskChunkDir, this::returnMaskChunkDirectory);
+                handleFor(router, patternForMaskLabeledChunkDir, this::returnMaskLabeledChunkDirectory);
             } else {
-                handleFor(router, patternForGroupDir, this::returnGroupDirectoryFlattened);
+                handleFor(router, patternForImageGroupDir, this::returnImageGroupDirectoryFlattened);
+                handleFor(router, patternForMaskDir, this::returnMaskDirectoryFlattened);
+                handleFor(router, patternForMaskLabeledDir, this::returnMaskLabeledDirectoryFlattened);
             }
+            handleFor(router, patternForImageMasksDir, this::returnImageMasksDirectory);
         }
-        handleFor(router, patternForGroup, this::returnGroup);
-        handleFor(router, patternForAttrs, this::returnAttrs);
-        handleFor(router, patternForArray, this::returnArray);
-        handleFor(router, patternForChunk, this::returnChunk);
+        handleFor(router, patternForImageGroup, this::returnGroup);
+        handleFor(router, patternForImageMasksGroup, this::returnGroup);
+        handleFor(router, patternForImageAttrs, this::returnImageAttrs);
+        handleFor(router, patternForImageMasksAttrs, this::returnImageMasksAttrs);
+        handleFor(router, patternForMaskAttrs, this::returnMaskAttrs);
+        handleFor(router, patternForMaskLabeledAttrs, this::returnMaskLabeledAttrs);
+        handleFor(router, patternForImageArray, this::returnImageArray);
+        handleFor(router, patternForMaskArray, this::returnMaskArray);
+        handleFor(router, patternForMaskLabeledArray, this::returnMaskLabeledArray);
+        handleFor(router, patternForImageChunk, this::returnImageChunk);
+        handleFor(router, patternForMaskChunk, this::returnMaskChunk);
+        handleFor(router, patternForMaskLabeledChunk, this::returnMaskLabeledChunk);
     }
 
     /**
@@ -436,48 +563,11 @@ public class RequestHandlerForImage implements HttpHandler {
     }
 
     /**
-     * Handle a request for the image directory.
-     * @param response the HTTP server response to populate
-     * @param parameters the parameters of the request to handle
+     * Helper for building directory contents: adds entries for flattened chunks.
+     * @param contents the directory contents
+     * @param shape the dimensionality of the data
      */
-    private void returnImageDirectory(HttpServerResponse response, List<String> parameters) {
-        /* parse parameters from path */
-        final long imageId = Long.parseLong(parameters.get(0));
-        LOGGER.debug("providing directory listing for Image:{}", imageId);
-        /* gather data from pixels service */
-        final Pixels pixels = omeroDao.getPixels(imageId);
-        final int resolutions = getDataFromPixels(response, pixels, buffer ->  buffer.getResolutionLevels());
-        if (response.ended()) {
-            return;
-        }
-        /* package data for client */
-        final ImmutableList.Builder<String> contents = ImmutableList.builder();
-        contents.add(".zattrs");
-        contents.add(".zgroup");
-        for (int resolution = 0; resolution < resolutions; resolution++) {
-            contents.add(Integer.toString(resolution) + '/');
-        }
-        respondWithDirectory(response, "Image #" + imageId, contents.build());
-    }
-
-    /**
-     * Handle a request for the group directory in flattened mode.
-     * @param response the HTTP server response to populate
-     * @param parameters the parameters of the request to handle
-     */
-    private void returnGroupDirectoryFlattened(HttpServerResponse response, List<String> parameters) {
-        /* parse parameters from path */
-        final long imageId = Long.parseLong(parameters.get(0));
-        final int resolution = Integer.parseInt(parameters.get(1));
-        LOGGER.debug("providing flattened directory listing for resolution {} of Image:{}", resolution, imageId);
-        /* gather data from pixels service */
-        final DataShape shape = getDataShape(response, imageId, resolution);
-        if (response.ended()) {
-            return;
-        }
-        /* package data for client */
-        final ImmutableList.Builder<String> contents = ImmutableList.builder();
-        contents.add(".zarray");
+    private static void addChunkEntriesFlattened(ImmutableCollection.Builder<String> contents, DataShape shape) {
         for (int t = 0; t < shape.tSize; t += 1) {
             for (int c = 0; c < shape.cSize; c += 1) {
                 for (int z = 0; z < shape.zSize; z += shape.zTile) {
@@ -489,56 +579,15 @@ public class RequestHandlerForImage implements HttpHandler {
                 }
             }
         }
-        respondWithDirectory(response, "Image #" + imageId + ", resolution " + resolution + " (flattened)", contents.build());
     }
 
     /**
-     * Handle a request for the group directory in nested mode.
-     * @param response the HTTP server response to populate
-     * @param parameters the parameters of the request to handle
+     * Helper for building directory contents: adds entries for nested chunks.
+     * @param contents the directory contents
+     * @param shape the dimensionality of the data
+     * @param depth the depth <q>into</q> the chunk, ranging from zero to four inclusive
      */
-    private void returnGroupDirectoryNested(HttpServerResponse response, List<String> parameters) {
-        /* parse parameters from path */
-        final long imageId = Long.parseLong(parameters.get(0));
-        final int resolution = Integer.parseInt(parameters.get(1));
-        returnGroupDirectoryNested(response, imageId, resolution, 0);
-    }
-
-    /**
-     * Handle a request for the chunk directory in nested mode.
-     * @param response the HTTP server response to populate
-     * @param parameters the parameters of the request to handle
-     */
-    private void returnChunkDirectory(HttpServerResponse response, List<String> parameters) {
-        /* parse parameters from path */
-        final long imageId = Long.parseLong(parameters.get(0));
-        final int resolution = Integer.parseInt(parameters.get(1));
-        final List<Integer> chunkDir = getIndicesFromPath(parameters.get(2));
-        if (chunkDir.size() >= 5) {
-            throw new IllegalArgumentException("chunks must have five dimensions");
-        }
-        returnGroupDirectoryNested(response, imageId, resolution, chunkDir.size());
-    }
-
-    /**
-     * Handle a request for the group directory in nested mode.
-     * @param response the HTTP server response to populate
-     * @param imageId the ID of the image being queried
-     * @param resolution the resolution to query
-     * @param depth how many directory levels inside the group
-     */
-    private void returnGroupDirectoryNested(HttpServerResponse response, long imageId, int resolution, int depth) {
-        LOGGER.debug("providing nested directory listing for resolution {} of Image:{} at depth {}", resolution, imageId, depth);
-        /* gather data from pixels service */
-        final DataShape shape = getDataShape(response, imageId, resolution);
-        if (response.ended()) {
-            return;
-        }
-        /* package data for client */
-        final ImmutableList.Builder<String> contents = ImmutableList.builder();
-        if (depth == 0) {
-            contents.add(".zarray");
-        }
+    private static void addChunkEntriesNested(ImmutableCollection.Builder<String> contents, DataShape shape, int depth) {
         final int extent, step;
         switch (depth) {
         case 0:
@@ -573,7 +622,336 @@ public class RequestHandlerForImage implements HttpHandler {
             }
             contents.add(content.toString());
         }
-        respondWithDirectory(response, "Image #" + imageId + ", resolution " + resolution + " (nested)", contents.build());
+    }
+
+    /**
+     * Handle a request for the image directory.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageDirectory(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing directory listing for Image:{}", imageId);
+        /* gather data from pixels service */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final int resolutions = getDataFromPixels(response, pixels, buffer ->  buffer.getResolutionLevels());
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        contents.add(".zattrs");
+        contents.add(".zgroup");
+        for (final long roiId : omeroDao.getRoiIdsOfImage(imageId)) {
+            if (omeroDao.getMaskCountOfRoi(roiId) > 0) {
+                contents.add("masks/");
+                break;
+            }
+        }
+        for (int resolution = 0; resolution < resolutions; resolution++) {
+            contents.add(Integer.toString(resolution) + '/');
+        }
+        respondWithDirectory(response, "Image #" + imageId, contents.build());
+    }
+
+    /**
+     * Handle a request for the group directory in flattened mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageGroupDirectoryFlattened(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final int resolution = Integer.parseInt(parameters.get(1));
+        LOGGER.debug("providing flattened directory listing for resolution {} of Image:{}", resolution, imageId);
+        /* gather data from pixels service */
+        final DataShape shape = getDataShape(response, imageId, resolution);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        contents.add(".zarray");
+        addChunkEntriesFlattened(contents, shape);
+        respondWithDirectory(response, "Image #" + imageId + ", resolution " + resolution + " (flattened)", contents.build());
+    }
+
+    /**
+     * Handle a request for the group directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageGroupDirectoryNested(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final int resolution = Integer.parseInt(parameters.get(1));
+        returnImageGroupDirectoryNested(response, imageId, resolution, 0);
+    }
+
+    /**
+     * Handle a request for the chunk directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageChunkDirectory(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final int resolution = Integer.parseInt(parameters.get(1));
+        final List<Integer> chunkDir = getIndicesFromPath(parameters.get(2));
+        if (chunkDir.size() >= 5) {
+            throw new IllegalArgumentException("chunks must have five dimensions");
+        }
+        returnImageGroupDirectoryNested(response, imageId, resolution, chunkDir.size());
+    }
+
+    /**
+     * Handle a request for the group directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param imageId the ID of the image being queried
+     * @param resolution the resolution to query
+     * @param depth how many directory levels inside the group
+     */
+    private void returnImageGroupDirectoryNested(HttpServerResponse response, long imageId, int resolution, int depth) {
+        LOGGER.debug("providing nested directory listing for resolution {} of Image:{} at depth {}", resolution, imageId, depth);
+        /* gather data from pixels service */
+        final DataShape shape = getDataShape(response, imageId, resolution);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        if (depth == 0) {
+            contents.add(".zarray");
+        }
+        addChunkEntriesNested(contents, shape, depth);
+        respondWithDirectory(response, "Image #" + imageId + ", resolution " + resolution, contents.build());
+    }
+
+    /**
+     * Get the IDs of the ROIs that have masks.
+     * @param imageId the image whose ROIs should be queried
+     * @return the IDs of the ROIs that have masks, may be an empty collection
+     */
+    private Collection<Long> getRoiIdsWithMask(long imageId) {
+        return omeroDao.getRoiIdsOfImage(imageId).stream()
+                .filter(roiId -> omeroDao.getMaskCountOfRoi(roiId) > 0)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Handle a request for the masks of an image directory.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageMasksDirectory(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing directory listing for Masks of Image:{}", imageId);
+        /* gather data from database */
+        final Collection<Long> roiIdsWithMask = getRoiIdsWithMask(imageId);
+        final Map<Long, Bitmask> labeledMasks = roiIdsWithMask.isEmpty() ? null : getLabeledMasks(imageId);
+        if (roiIdsWithMask.isEmpty()) {
+            fail(response, 404, "no image masks for that id");
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        contents.add(".zattrs");
+        if (labeledMasks != null) {
+            contents.add("labeled/");
+        }
+        for (long roiId : roiIdsWithMask) {
+            contents.add(Long.toString(roiId) + '/');
+        }
+        respondWithDirectory(response, "Masks of Image #" + imageId, contents.build());
+    }
+
+    /**
+     * Handle a request for the group directory in flattened mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskDirectoryFlattened(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        LOGGER.debug("providing flattened directory listing for Mask:{}", roiId);
+        /* gather data */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Roi roi = omeroDao.getRoi(roiId);
+        if (roi == null || roi.getImage() == null || roi.getImage().getId() != imageId) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final SortedSet<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+        if (maskIds.isEmpty()) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final Bitmask imageMask = UnionMask.union(maskIds.stream()
+                .map(omeroDao::getMask).map(ImageMask::new).collect(Collectors.toList()));
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMask, 1))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        contents.add(".zarray");
+        contents.add(".zattrs");
+        addChunkEntriesFlattened(contents, shape);
+        respondWithDirectory(response, "Mask #" + roiId + " (flattened)", contents.build());
+    }
+
+    /**
+     * Handle a request for the mask directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskDirectoryNested(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        returnMaskDirectoryNested(response, imageId, roiId, 0);
+    }
+
+    /**
+     * Handle a request for the chunk directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskChunkDirectory(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        final List<Integer> chunkDir = getIndicesFromPath(parameters.get(2));
+        if (chunkDir.size() >= 5) {
+            throw new IllegalArgumentException("chunks must have five dimensions");
+        }
+        returnMaskDirectoryNested(response, imageId, roiId, chunkDir.size());
+    }
+
+    /**
+     * Handle a request for the mask directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param roiId the ID of the mask being queried
+     * @param depth how many directory levels inside the group
+     */
+    private void returnMaskDirectoryNested(HttpServerResponse response, long imageId, long roiId, int depth) {
+        LOGGER.debug("providing directory listing for Mask:{}", roiId);
+        /* gather data */
+        final Roi roi = omeroDao.getRoi(roiId);
+        if (roi == null || roi.getImage() == null || roi.getImage().getId() != imageId) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final SortedSet<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+        if (maskIds.isEmpty()) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Bitmask imageMask = UnionMask.union(maskIds.stream()
+                .map(omeroDao::getMask).map(ImageMask::new).collect(Collectors.toList()));
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMask, 1))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        if (depth == 0) {
+            contents.add(".zarray");
+            contents.add(".zattrs");
+        }
+        addChunkEntriesNested(contents, shape, depth);
+        respondWithDirectory(response, "Mask #" + roiId, contents.build());
+    }
+
+    /**
+     * Handle a request for the group directory in flattened mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledDirectoryFlattened(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing flattened directory listing for labeled Mask of Image:{}", imageId);
+        final Map<Long, Bitmask> labeledMasks = getLabeledMasks(imageId);
+        if (labeledMasks == null) {
+            fail(response, 404, "the image for that id does not have a labeled mask");
+            return;
+        }
+        /* gather data */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Collection<Bitmask> imageMasks = labeledMasks.values();
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMasks, Long.BYTES))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        contents.add(".zarray");
+        contents.add(".zattrs");
+        addChunkEntriesFlattened(contents, shape);
+        respondWithDirectory(response, "Labeled Mask of Image #" + imageId + " (flattened)", contents.build());
+    }
+
+    /**
+     * Handle a request for the mask directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledDirectoryNested(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        returnMaskLabeledDirectoryNested(response, imageId, 0);
+    }
+
+    /**
+     * Handle a request for the chunk directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledChunkDirectory(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final List<Integer> chunkDir = getIndicesFromPath(parameters.get(1));
+        if (chunkDir.size() >= 5) {
+            throw new IllegalArgumentException("chunks must have five dimensions");
+        }
+        returnMaskLabeledDirectoryNested(response, imageId, chunkDir.size());
+    }
+
+    /**
+     * Handle a request for the mask directory in nested mode.
+     * @param response the HTTP server response to populate
+     * @param roiId the ID of the mask being queried
+     * @param depth how many directory levels inside the group
+     */
+    private void returnMaskLabeledDirectoryNested(HttpServerResponse response, long imageId, int depth) {
+        LOGGER.debug("providing directory listing for labeled Mask of Image:{}", imageId);
+        final Map<Long, Bitmask> labeledMasks = getLabeledMasks(imageId);
+        if (labeledMasks == null) {
+            fail(response, 404, "the image for that id does not have a labeled mask");
+            return;
+        }
+        /* gather data */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Collection<Bitmask> imageMasks = labeledMasks.values();
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMasks, Long.BYTES))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final ImmutableList.Builder<String> contents = ImmutableList.builder();
+        if (depth == 0) {
+            contents.add(".zarray");
+            contents.add(".zattrs");
+        }
+        addChunkEntriesNested(contents, shape, depth);
+        respondWithDirectory(response, "Labeled Mask of Image #" + imageId, contents.build());
     }
 
     /**
@@ -597,7 +975,7 @@ public class RequestHandlerForImage implements HttpHandler {
     }
 
     /**
-     * Build OMERO metadata for {@link #returnAttrs(HttpServerResponse, long)} to include with a {@code "omero"} key.
+     * Build OMERO metadata for {@link #returnImageAttrs(HttpServerResponse, long)} to include with a {@code "omero"} key.
      * @param pixels the {@link Pixels} instance for which to build the metadata
      * @return the nested metadata
      */
@@ -678,11 +1056,11 @@ public class RequestHandlerForImage implements HttpHandler {
     }
 
     /**
-     * Handle a request for {@code .zattrs}.
+     * Handle a request for {@code .zattrs} of an image.
      * @param response the HTTP server response to populate
      * @param parameters the parameters of the request to handle
      */
-    private void returnAttrs(HttpServerResponse response, List<String> parameters) {
+    private void returnImageAttrs(HttpServerResponse response, List<String> parameters) {
         /* parse parameters from path */
         final long imageId = Long.parseLong(parameters.get(0));
         LOGGER.debug("providing .zattrs for Image:{}", imageId);
@@ -739,11 +1117,180 @@ public class RequestHandlerForImage implements HttpHandler {
     }
 
     /**
-     * Handle a request for {@code .zarray}.
+     * Handle a request for {@code .zattrs} of an image's masks.
      * @param response the HTTP server response to populate
      * @param parameters the parameters of the request to handle
      */
-    private void returnArray(HttpServerResponse response, List<String> parameters) {
+    private void returnImageMasksAttrs(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing .zattrs for Masks of Image:{}", imageId);
+        /* gather data */
+        final Collection<Long> roiIdsWithMask = getRoiIdsWithMask(imageId);
+        final Map<Long, Bitmask> labeledMasks = roiIdsWithMask.isEmpty() ? null : getLabeledMasks(imageId);
+        if (roiIdsWithMask.isEmpty()) {
+            fail(response, 404, "no image masks for that id");
+            return;
+        }
+        final List<String> masks = new ArrayList<>(roiIdsWithMask.size() + 1);
+        if (labeledMasks != null) {
+            masks.add("labeled");
+        }
+        for (final long roiId : roiIdsWithMask) {
+            masks.add(Long.toString(roiId));
+        }
+        /* package data for client */
+        final Map<String, Object> result = new HashMap<>();
+        result.put("masks", masks);
+        respondWithJson(response, new JsonObject(result));
+    }
+
+    /**
+     * Handle a request for {@code .zattrs} for a mask of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskAttrs(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        LOGGER.debug("providing .zattrs for Mask:{}", roiId);
+        /* gather data */
+        final Roi roi = omeroDao.getRoi(roiId);
+        if (roi == null || roi.getImage() == null || roi.getImage().getId() != imageId) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final SortedSet<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+        if (maskIds.isEmpty()) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        /* package data for client */
+        final Map<String, Object> image = new HashMap<>();
+        image.put("array", "../../0/");
+        final Map<String, Object> result = new HashMap<>();
+        result.put("image", image);
+        respondWithJson(response, new JsonObject(result));
+    }
+
+    /**
+     * If there are no overlaps among the masks then provide a labeled mask for the given image.
+     * @param imageId an image ID
+     * @return a labeled mask, or {@code null} if there are no masks or overlapping masks
+     */
+    private Map<Long, Bitmask> getLabeledMasks(long imageId) {
+        try {
+            final Optional<Map<Long, Bitmask>> labeledMasks = labeledMaskCache.get(imageId);
+            return labeledMasks.isPresent() ? labeledMasks.get() : null;
+        } catch (ExecutionException ee) {
+            LOGGER.warn("failed to get labeled masks for image {}", imageId, ee.getCause());
+            return null;
+        }
+    }
+
+    /**
+     * If there are no overlaps among the masks then construct a labeled mask for the given image.
+     * Intended to be used <em>only</em> by {@link #labeledMaskCache} because
+     * other callers should benefit from the cache by using {@link #getLabeledMasks(long)}.
+     * @param imageId an image ID
+     * @return a labeled mask, or {@code null} if there are no masks or overlapping masks
+     */
+    private Map<Long, Bitmask> getLabeledMasksForCache(long imageId) {
+        final List<Long> roiIds = new ArrayList<>();
+        for (final long roiId : getRoiIdsWithMask(imageId)) {
+            roiIds.add(roiId);
+        }
+        if (roiIds.isEmpty()) {
+            return null;
+        }
+        final Map<Long, Bitmask> labeledMasks = new HashMap<>();
+        for (final long roiId : roiIds) {
+            final Collection<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+            final Bitmask imageMask = UnionMask.union(maskIds.stream()
+                    .map(omeroDao::getMask).map(ImageMask::new).collect(Collectors.toList()));
+            labeledMasks.put(roiId, imageMask);
+        }
+        /* Check that there are no overlaps. */
+        for (final Map.Entry<Long, Bitmask> labeledMask1 : labeledMasks.entrySet()) {
+            final long label1 = labeledMask1.getKey();
+            final Bitmask mask1 = labeledMask1.getValue();
+            if (mask1 instanceof ImageMask) {
+                final ImageMask imageMask1 = (ImageMask) mask1;
+                for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
+                    final long label2 = labeledMask2.getKey();
+                    final Bitmask mask2 = labeledMask2.getValue();
+                    if (label1 < label2) {
+                        if (mask2 instanceof ImageMask) {
+                            final ImageMask imageMask2 = (ImageMask) mask2;
+                            if (imageMask2.isOverlap(imageMask1)) {
+                                return null;
+                            }
+                        } else if (mask2 instanceof UnionMask) {
+                            final UnionMask unionMask2 = (UnionMask) mask2;
+                            if (unionMask2.isOverlap(imageMask1)) {
+                                return null;
+                            }
+                        } else {
+                            throw new IllegalStateException();
+                        }
+                    }
+                }
+            } else if (mask1 instanceof UnionMask) {
+                final UnionMask unionMask1 = (UnionMask) mask1;
+                for (final Map.Entry<Long, Bitmask> labeledMask2 : labeledMasks.entrySet()) {
+                    final long label2 = labeledMask2.getKey();
+                    final Bitmask mask2 = labeledMask2.getValue();
+                    if (label1 < label2) {
+                        if (mask2 instanceof ImageMask) {
+                            final ImageMask imageMask2 = (ImageMask) mask2;
+                            if (unionMask1.isOverlap(imageMask2)) {
+                                return null;
+                            }
+                        } else if (mask2 instanceof UnionMask) {
+                            final UnionMask unionMask2 = (UnionMask) mask2;
+                            if (unionMask1.isOverlap(unionMask2)) {
+                                return null;
+                            }
+                        } else {
+                            throw new IllegalStateException();
+                        }
+                    }
+                }
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+        return labeledMasks;
+    }
+
+    /**
+     * Handle a request for {@code .zattrs} for the labeled mask of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledAttrs(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing .zattrs for labeled Mask of Image:{}", imageId);
+        /* gather data */
+        final Map<Long, Bitmask> labeledMasks = getLabeledMasks(imageId);
+        if (labeledMasks == null) {
+            fail(response, 404, "the image for that id does not have a labeled mask");
+            return;
+        }
+        /* package data for client */
+        final Map<String, Object> image = new HashMap<>();
+        image.put("array", "../../0/");
+        final Map<String, Object> result = new HashMap<>();
+        result.put("image", image);
+        respondWithJson(response, new JsonObject(result));
+    }
+
+    /**
+     * Handle a request for {@code .zarray} for an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageArray(HttpServerResponse response, List<String> parameters) {
         /* parse parameters from path */
         final long imageId = Long.parseLong(parameters.get(0));
         final int resolution = Integer.parseInt(parameters.get(1));
@@ -794,11 +1341,231 @@ public class RequestHandlerForImage implements HttpHandler {
     }
 
     /**
-     * Handle a request for a chunk of the pixel data.
+     * Handle a request for {@code .zarray} for a mask of an image.
      * @param response the HTTP server response to populate
      * @param parameters the parameters of the request to handle
      */
-    private void returnChunk(HttpServerResponse response, List<String> parameters) {
+    private void returnMaskArray(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        LOGGER.debug("providing .zarray for Mask:{}", roiId);
+        /* gather data */
+        final Roi roi = omeroDao.getRoi(roiId);
+        if (roi == null || roi.getImage() == null || roi.getImage().getId() != imageId) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final SortedSet<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+        if (maskIds.isEmpty()) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        /* gather data */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Bitmask imageMask = UnionMask.union(maskIds.stream()
+                .map(omeroDao::getMask).map(ImageMask::new).collect(Collectors.toList()));
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMask, 1))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final Map<String, Object> compressor = new HashMap<>();
+        compressor.put("id", "zlib");
+        compressor.put("level", deflateLevel);
+        final Map<String, Object> result = new HashMap<>();
+        result.put("zarr_format", 2);
+        result.put("order", "C");
+        result.put("shape", ImmutableList.of(shape.tSize, shape.cSize, shape.zSize, shape.ySize, shape.xSize));
+        result.put("chunks", ImmutableList.of(1, 1, shape.zTile, shape.yTile, shape.xTile));
+        result.put("fill_value", false);
+        result.put("dtype", "|b1");
+        result.put("filters", null);
+        result.put("compressor", compressor);
+        respondWithJson(response, new JsonObject(result));
+    }
+
+    /**
+     * Handle a request for {@code .zarray} for the labeled mask of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledArray(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        LOGGER.debug("providing .zarray for labeled Mask of Image:{}", imageId);
+        /* gather data */
+        final Map<Long, Bitmask> labeledMasks = getLabeledMasks(imageId);
+        if (labeledMasks == null) {
+            fail(response, 404, "the image for that id does not have a labeled mask");
+            return;
+        }
+        /* gather data */
+        final Pixels pixels = omeroDao.getPixels(imageId);
+        final Collection<Bitmask> imageMasks = labeledMasks.values();
+        final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMasks, Long.BYTES))
+                .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+        if (response.ended()) {
+            return;
+        }
+        /* package data for client */
+        final Map<String, Object> compressor = new HashMap<>();
+        compressor.put("id", "zlib");
+        compressor.put("level", deflateLevel);
+        final Map<String, Object> result = new HashMap<>();
+        result.put("zarr_format", 2);
+        result.put("order", "C");
+        result.put("shape", ImmutableList.of(shape.tSize, shape.cSize, shape.zSize, shape.ySize, shape.xSize));
+        result.put("chunks", ImmutableList.of(1, 1, shape.zTile, shape.yTile, shape.xTile));
+        result.put("fill_value", false);
+        result.put("dtype", ">u8");
+        result.put("filters", null);
+        result.put("compressor", compressor);
+        respondWithJson(response, new JsonObject(result));
+    }
+
+    /**
+     * Constructs tiles on request.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since v0.1.6
+     */
+    private interface TileGetter {
+        /**
+         * Construct the tile at the given position.
+         * @param x the leftmost extent of the tile
+         * @param y the topmost extent of the tile
+         * @param w the width of the tile
+         * @param h the height of the tile
+         * @return the tile
+         * @throws IOException from the OMERO pixel buffer
+         */
+        byte[] getTile(int x, int y, int w, int h) throws IOException;
+    }
+
+    /**
+     * Transfers pixel data from a tile into the given chunk array.
+     * @param chunk the chunk into which to write
+     * @param offset the byte offset from which to write
+     * @param tileGetter the source of pixel data for the tile
+     * @param shape the dimensionality of the chunk and the tile
+     * @param x the leftmost extent of the tile
+     * @param y the topmost extent of the tile
+     * @throws IOException from {@link TileGetter#getTile(int, int, int, int)}
+     */
+    private static void getTileIntoChunk(byte[] chunk, int offset, TileGetter tileGetter, DataShape shape, int x, int y)
+            throws IOException {
+        if (x + shape.xTile > shape.xSize) {
+            /* a tile that crosses the right side of the image */
+            final int xd = shape.xSize - x;
+            final int yd;
+            if (y + shape.yTile > shape.ySize) {
+                /* also crosses the bottom side */
+                yd = shape.ySize - y;
+            } else {
+                /* does not cross the bottom side */
+                yd = shape.yTile;
+            }
+            final byte[] chunkSrc = tileGetter.getTile(x, y, xd, yd);
+            /* must now assemble row-by-row into a plane in the chunk */
+            for (int row = 0; row < yd; row++) {
+                final int srcIndex = row * xd * shape.byteWidth;
+                final int dstIndex = row * shape.xTile * shape.byteWidth + offset;
+                System.arraycopy(chunkSrc, srcIndex, chunk, dstIndex, xd * shape.byteWidth);
+            }
+        } else {
+            final int yd;
+            if (y + shape.yTile > shape.ySize) {
+                /* a tile that crosses the bottom of the image */
+                yd = shape.ySize - y;
+            } else {
+                /* the tile fills a plane in the chunk */
+                yd = shape.yTile;
+            }
+            final byte[] chunkSrc = tileGetter.getTile(x, y, shape.xTile, yd);
+            /* simply copy into the plane */
+            System.arraycopy(chunkSrc, 0, chunk, offset, chunkSrc.length);
+        }
+    }
+
+    /**
+     * Construct a tile getter that obtains pixel data from an OMERO pixel buffer.
+     * @param buffer the pixel buffer
+     * @param z the <em>Z</em> index of the plane from which to fetch pixel data
+     * @param c the <em>C</em> index of the plane from which to fetch pixel data
+     * @param t the <em>T</em> index of the plane from which to fetch pixel data
+     * @return a tile getter for that plane
+     */
+    private TileGetter buildTileGetter(PixelBuffer buffer, int z, int c, int t) {
+        return new TileGetter() {
+            @Override
+            public byte[] getTile(int x, int y, int w, int h) throws IOException {
+                final PixelData tile = buffer.getTile(z, c, t, x, y, w, h);
+                final byte[] tileData = tile.getData().array();
+                tile.dispose();
+                return tileData;
+            }
+        };
+    }
+
+    /**
+     * Construct a tile getter for a split mask.
+     * @param isMasked the source of mask data
+     * @return a tile for the split mask, each pixel occupying one byte set to zero or non-zero
+     */
+    private TileGetter buildTileGetter(BiPredicate<Integer, Integer> isMasked) {
+        return new TileGetter() {
+            @Override
+            public byte[] getTile(int x, int y, int w, int h) {
+                final byte[] tile = new byte[w * h];
+                int tilePosition = 0;
+                for (int yCurr = y; yCurr < y + h; yCurr++) {
+                    for (int xCurr = x; xCurr < x + w; xCurr++) {
+                        if (isMasked.test(xCurr, yCurr)) {
+                            tile[tilePosition] = -1;
+                        }
+                        tilePosition++;
+                    }
+                }
+                return tile;
+            }
+        };
+    }
+
+    /**
+     * Construct a tile getter for a labeled mask.
+     * @param isMasked the source of mask data
+     * @return a tile for the split mask, each pixel occupying {@link Long#BYTES} set to zero or the label
+     */
+    private TileGetter buildTileGetter(Map<Long, BiPredicate<Integer, Integer>> imageMasksByLabel) {
+        return new TileGetter() {
+            @Override
+            public byte[] getTile(int x, int y, int w, int h) {
+                final ByteBuffer tile = ByteBuffer.allocate(w * h * Long.BYTES);
+                int tilePosition = 0;
+                for (int yCurr = y; yCurr < y + h; yCurr++) {
+                    for (int xCurr = x; xCurr < x + w; xCurr++) {
+                        for (final Map.Entry<Long, BiPredicate<Integer, Integer>> imageMaskWithLabel :
+                            imageMasksByLabel.entrySet()) {
+                            final long label = imageMaskWithLabel.getKey();
+                            final BiPredicate<Integer, Integer> isMasked = imageMaskWithLabel.getValue();
+                            if (isMasked.test(xCurr, yCurr)) {
+                                tile.putLong(tilePosition, label);
+                                break;
+                            }
+                        }
+                        tilePosition += Long.BYTES;
+                    }
+                }
+                return tile.array();
+            }
+        };
+    }
+
+    /**
+     * Handle a request for a chunk of the pixel data of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnImageChunk(HttpServerResponse response, List<String> parameters) {
         /* parse parameters from path */
         final long imageId = Long.parseLong(parameters.get(0));
         final int resolution = Integer.parseInt(parameters.get(1));
@@ -829,41 +1596,8 @@ public class RequestHandlerForImage implements HttpHandler {
             chunk = new byte[shape.xTile * shape.yTile * shape.zTile * shape.byteWidth];
             for (int plane = 0; plane < shape.zTile && z + plane < shape.zSize; plane++) {
                 final int planeOffset = plane * (chunk.length / shape.zTile);
-                final PixelData tile;
-                if (x + shape.xTile > shape.xSize) {
-                    /* a tile that crosses the right side of the image */
-                    final int xd = shape.xSize - x;
-                    final int yd;
-                    if (y + shape.yTile > shape.ySize) {
-                        /* also crosses the bottom side */
-                        yd = shape.ySize - y;
-                    } else {
-                        /* does not cross the bottom side */
-                        yd = shape.yTile;
-                    }
-                    tile = buffer.getTile(z + plane, c, t, x, y, xd, yd);
-                    final byte[] chunkSrc = tile.getData().array();
-                    /* must now assemble row-by-row into a plane in the chunk */
-                    for (int row = 0; row < yd; row++) {
-                        final int srcIndex = row * xd * shape.byteWidth;
-                        final int dstIndex = row * shape.xTile * shape.byteWidth + planeOffset;
-                        System.arraycopy(chunkSrc, srcIndex, chunk, dstIndex, xd * shape.byteWidth);
-                    }
-                } else {
-                    final int yd;
-                    if (y + shape.yTile > shape.ySize) {
-                        /* a tile that crosses the bottom of the image */
-                        yd = shape.ySize - y;
-                    } else {
-                        /* the tile fills a plane in the chunk */
-                        yd = shape.yTile;
-                    }
-                    tile = buffer.getTile(z + plane, c, t, x, y, shape.xTile, yd);
-                    final byte[] chunkSrc = tile.getData().array();
-                    /* simply copy into the plane */
-                    System.arraycopy(chunkSrc, 0, chunk, planeOffset, chunkSrc.length);
-                }
-                tile.dispose();
+                final TileGetter tileGetter = buildTileGetter(buffer, z + plane, c, t);
+                getTileIntoChunk(chunk, planeOffset, tileGetter, shape, x, y);
             }
         } catch (Exception e) {
             LOGGER.debug("pixel buffer failure", e);
@@ -873,6 +1607,140 @@ public class RequestHandlerForImage implements HttpHandler {
             if (buffer != null) {
                 cache.releasePixelBuffer(buffer);
             }
+        }
+        /* package data for client */
+        final Buffer chunkZipped = compress(chunk);
+        final int responseSize = chunkZipped.length();
+        LOGGER.debug("constructed binary response of size {}", responseSize);
+        response.putHeader("Content-Type", "application/octet-stream");
+        response.putHeader("Content-Length", Integer.toString(responseSize));
+        response.end(chunkZipped);
+    }
+
+    /**
+     * Handle a request for a chunk of the mask of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskChunk(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final long roiId = Long.parseLong(parameters.get(1));
+        final List<Integer> chunkId = getIndicesFromPath(parameters.get(2));
+        if (chunkId.size() != 5) {
+            throw new IllegalArgumentException("chunks must have five dimensions");
+        }
+        LOGGER.debug("providing chunk {} of Mask:{}", chunkId, roiId);
+        /* gather data */
+        final Roi roi = omeroDao.getRoi(roiId);
+        if (roi == null || roi.getImage() == null || roi.getImage().getId() != imageId) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        final SortedSet<Long> maskIds = omeroDao.getMaskIdsOfRoi(roiId);
+        if (maskIds.isEmpty()) {
+            throw new IllegalArgumentException("image has no such mask");
+        }
+        /* gather data */
+        final byte[] chunk;
+        try {
+            final Pixels pixels = omeroDao.getPixels(imageId);
+            final Bitmask imageMask = UnionMask.union(maskIds.stream()
+                    .map(omeroDao::getMask).map(ImageMask::new).collect(Collectors.toList()));
+            final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMask, 1))
+                    .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+            if (response.ended()) {
+                return;
+            }
+            final int x = shape.xTile * chunkId.get(4);
+            final int y = shape.yTile * chunkId.get(3);
+            final int z = shape.zTile * chunkId.get(2);
+            final int c = chunkId.get(1);
+            final int t = chunkId.get(0);
+            if (x >= shape.xSize || y >= shape.ySize || c >= shape.cSize || z >= shape.zSize || t >= shape.tSize) {
+                fail(response, 404, "no chunk with that index");
+                return;
+            }
+            chunk = new byte[shape.xTile * shape.yTile * shape.zTile * shape.byteWidth];
+            for (int plane = 0; plane < shape.zTile && z + plane < shape.zSize; plane++) {
+                final BiPredicate<Integer, Integer> isMasked = imageMask.getMaskReader(z + plane, c, t);
+                if (isMasked != null)  {
+                    final int planeOffset = plane * (chunk.length / shape.zTile);
+                    final TileGetter tileGetter = buildTileGetter(isMasked);
+                    getTileIntoChunk(chunk, planeOffset, tileGetter, shape, x, y);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("pixel buffer failure", e);
+            fail(response, 500, "query failed");
+            return;
+        }
+        /* package data for client */
+        final Buffer chunkZipped = compress(chunk);
+        final int responseSize = chunkZipped.length();
+        LOGGER.debug("constructed binary response of size {}", responseSize);
+        response.putHeader("Content-Type", "application/octet-stream");
+        response.putHeader("Content-Length", Integer.toString(responseSize));
+        response.end(chunkZipped);
+    }
+
+    /**
+     * Handle a request for a chunk of the labeled mask of an image.
+     * @param response the HTTP server response to populate
+     * @param parameters the parameters of the request to handle
+     */
+    private void returnMaskLabeledChunk(HttpServerResponse response, List<String> parameters) {
+        /* parse parameters from path */
+        final long imageId = Long.parseLong(parameters.get(0));
+        final List<Integer> chunkId = getIndicesFromPath(parameters.get(1));
+        if (chunkId.size() != 5) {
+            throw new IllegalArgumentException("chunks must have five dimensions");
+        }
+        LOGGER.debug("providing chunk {} of labeled Mask of Image:{}", chunkId, imageId);
+        /* gather data */
+        final Map<Long, Bitmask> labeledMasks = getLabeledMasks(imageId);
+        if (labeledMasks == null) {
+            fail(response, 404, "the image for that id does not have a labeled mask");
+            return;
+        }
+        final byte[] chunk;
+        try {
+            final Pixels pixels = omeroDao.getPixels(imageId);
+            final Collection<Bitmask> imageMasks = labeledMasks.values();
+            final DataShape shape = getDataFromPixels(response, pixels, buffer ->  new DataShape(buffer, imageMasks, Long.BYTES))
+                    .adjustTileSize(chunkSizeAdjust, chunkSizeMin);
+            if (response.ended()) {
+                return;
+            }
+            final int x = shape.xTile * chunkId.get(4);
+            final int y = shape.yTile * chunkId.get(3);
+            final int z = shape.zTile * chunkId.get(2);
+            final int c = chunkId.get(1);
+            final int t = chunkId.get(0);
+            if (x >= shape.xSize || y >= shape.ySize || c >= shape.cSize || z >= shape.zSize || t >= shape.tSize) {
+                fail(response, 404, "no chunk with that index");
+                return;
+            }
+            chunk = new byte[shape.xTile * shape.yTile * shape.zTile * shape.byteWidth];
+            for (int plane = 0; plane < shape.zTile && z + plane < shape.zSize; plane++) {
+                final Map<Long, BiPredicate<Integer, Integer>> applicableMasks = new HashMap<>();
+                for (final Map.Entry<Long, Bitmask> labeledMask : labeledMasks.entrySet()) {
+                    final long label = labeledMask.getKey();
+                    final Bitmask mask = labeledMask.getValue();
+                    final BiPredicate<Integer, Integer> isMasked = mask.getMaskReader(z + plane, c, t);
+                    if (isMasked != null) {
+                        applicableMasks.put(label, isMasked);
+                    }
+                }
+                if (!applicableMasks.isEmpty()) {
+                    final int planeOffset = plane * (chunk.length / shape.zTile);
+                    final TileGetter tileGetter = buildTileGetter(applicableMasks);
+                    getTileIntoChunk(chunk, planeOffset, tileGetter, shape, x, y);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("pixel buffer failure", e);
+            fail(response, 500, "query failed");
+            return;
         }
         /* package data for client */
         final Buffer chunkZipped = compress(chunk);

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/Bitmask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/Bitmask.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.mask;
+
+import java.util.function.BiPredicate;
+
+/**
+ * The most abstract kind of bitmask.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.6
+ */
+public interface Bitmask {
+    /**
+     * @param dimension one of <q>XYZCT</q>
+     * @return if the value of this dimension may affect the result from any of the other methods
+     */
+    boolean isSignificant(char dimension);
+
+    /**
+     * @param z a <em>Z</em> plane
+     * @param c a <em>C</em> plane
+     * @param t a <em>T</em> plane
+     * @return an <em>X</em>, <em>Y</em> mask reader if the mask exists on the given plane, otherwise {@code null}
+     */
+    BiPredicate<Integer, Integer> getMaskReader(int z, int c, int t);
+
+    /**
+     * @return an estimate of the memory consumption of this mask, to guide cache management
+     */
+    int size();
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/Bitmask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/Bitmask.java
@@ -24,7 +24,7 @@ import java.util.function.BiPredicate;
 /**
  * The most abstract kind of bitmask.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since v0.1.6
+ * @since v0.1.7
  */
 public interface Bitmask {
     /**

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
@@ -96,7 +96,7 @@ public class ImageMask implements Bitmask {
      * @param t the optional <em>T</em> plane of the mask
      * @param bitmask the byte array to adopt as the bitmask
      */
-    private ImageMask(Rectangle pos, OptionalInt z, OptionalInt c, OptionalInt t, byte[] bitmask) {
+    ImageMask(Rectangle pos, OptionalInt z, OptionalInt c, OptionalInt t, byte[] bitmask) {
         this.pos = pos;
         this.z = z;
         this.c = c;

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.mask;
+
+import ome.model.roi.Mask;
+
+import java.awt.Rectangle;
+import java.util.OptionalInt;
+import java.util.function.BiPredicate;
+
+/**
+ * Represents a simple planar bitmask.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.6
+ */
+public class ImageMask implements Bitmask {
+
+    final OptionalInt z, c, t;
+    final Rectangle pos;
+    final byte[] bitmask;
+
+    /**
+     * Copy a byte array.
+     * @param src a byte array
+     * @return a copy of the byte array
+     */
+    private static byte[] copyBitmask(byte[] src) {
+        final byte[] dst = new byte[src.length];
+        System.arraycopy(src, 0, dst, 0, src.length);
+        return dst;
+    }
+
+    /**
+     * Construct an image mask.
+     * @param x the leftmost extent of the mask
+     * @param y the topmost extent of the mask
+     * @param width the width of the mask
+     * @param height the height of the mask
+     * @param z the <em>Z</em> plane of the mask, or {@code null} if it extends to all <em>Z</em> planes
+     * @param c the <em>C</em> plane of the mask, or {@code null} if it extends to all <em>C</em> planes
+     * @param t the <em>T</em> plane of the mask, or {@code null} if it extends to all <em>T</em> planes
+     * @param bitmask the actual bitmask, as packed bits ranging over <em>X</em> before <em>Y</em>
+     */
+    public ImageMask(int x, int y, int width, int height, Integer z, Integer c, Integer t, byte[] bitmask) {
+        if (width < 1 || height < 1) {
+            throw new IllegalArgumentException("dimensions of mask must be strictly positive");
+        }
+        if (bitmask == null) {
+            throw new IllegalArgumentException("bitmask cannot be null");
+        }
+        if (bitmask.length != width * height + 7 >> 3) {
+            throw new IllegalArgumentException(
+                    bitmask.length + "-byte mask not expected for " + width + '×' + height + " mask");
+        }
+        this.pos = new Rectangle(x, y, width, height);
+        this.z = z == null ? OptionalInt.empty() : OptionalInt.of(z);
+        this.c = c == null ? OptionalInt.empty() : OptionalInt.of(c);
+        this.t = t == null ? OptionalInt.empty() : OptionalInt.of(t);
+        this.bitmask = bitmask;
+    }
+
+    /**
+     * Construct an image mask from an OMERO mask.
+     * @param mask an OMERO mask
+     */
+    public ImageMask(Mask mask) {
+        this(mask.getX().intValue(), mask.getY().intValue(), mask.getWidth().intValue(), mask.getHeight().intValue(),
+                mask.getTheZ(), mask.getTheC(), mask.getTheT(), copyBitmask(mask.getBytes()));
+        if (pos.x != mask.getX() || pos.y != mask.getY() || pos.width != mask.getWidth() || pos.height != mask.getHeight()) {
+            throw new IllegalArgumentException("mask position must be specified as integers");
+        }
+    }
+
+    /**
+     * Construct an image mask, populating the fields with exactly the given object instances, with no validation.
+     * @param pos the position of the mask
+     * @param z the optional <em>Z</em> plane of the mask
+     * @param c the optional <em>C</em> plane of the mask
+     * @param t the optional <em>T</em> plane of the mask
+     * @param bitmask the byte array to adopt as the bitmask
+     */
+    private ImageMask(Rectangle pos, OptionalInt z, OptionalInt c, OptionalInt t, byte[] bitmask) {
+        this.pos = pos;
+        this.z = z;
+        this.c = c;
+        this.t = t;
+        this.bitmask = bitmask;
+    }
+
+    @Override
+    public boolean isSignificant(char dimension) {
+        switch (Character.toUpperCase(dimension)) {
+        case 'X':
+            return true;
+        case 'Y':
+            return true;
+        case 'Z':
+            return z.isPresent();
+        case 'C':
+            return c.isPresent();
+        case 'T':
+            return t.isPresent();
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public BiPredicate<Integer, Integer> getMaskReader(int z, int c, int t) {
+        if (this.z.isPresent() && this.z.getAsInt() != z ||
+            this.c.isPresent() && this.c.getAsInt() != c ||
+            this.t.isPresent() && this.t.getAsInt() != t) {
+            return null;
+        }
+        return new BiPredicate<Integer, Integer>() {
+            @Override
+            public boolean test(Integer x, Integer y) {
+                if (!pos.contains(x, y)) {
+                    return false;
+                }
+                final int bitPosition = (x - pos.x) + (y - pos.y) * pos.width;
+                final int bytePosition = bitPosition >> 3;
+                final int bitRemainder = 7 - (bitPosition & 7);
+                final int bitState = bitmask[bytePosition] & 1 << bitRemainder;
+                return bitState != 0;
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return bitmask.length;
+    }
+
+    /**
+     * Test if this mask overlaps another.
+     * @param mask a mask
+     * @return if this mask overlaps the given mask
+     */
+    public boolean isOverlap(ImageMask mask) {
+        /* Same planes? */
+        if (z.isPresent() && mask.z.isPresent() && z.getAsInt() != mask.z.getAsInt() ||
+            c.isPresent() && mask.c.isPresent() && c.getAsInt() != mask.c.getAsInt() ||
+            t.isPresent() && mask.t.isPresent() && t.getAsInt() != mask.t.getAsInt()) {
+            return false;
+        }
+        if (pos.equals(mask.pos)) {
+            /* If same position then the packing is aligned so compare byte-by-byte. */
+            for (int index = 0; index < bitmask.length; index++) {
+                if ((bitmask[index] & mask.bitmask[index]) != 0) {
+                    return true;
+                }
+            }
+        } else {
+            /* Different positions so check bit-by-bit. */
+            final int z = this.z.orElse(mask.z.orElse(1));
+            final int c = this.c.orElse(mask.c.orElse(1));
+            final int t = this.t.orElse(mask.t.orElse(1));
+            final BiPredicate<Integer, Integer> isMasked1 = this.getMaskReader(z, c, t);
+            final BiPredicate<Integer, Integer> isMasked2 = mask.getMaskReader(z, c, t);
+            final Rectangle intersection = pos.intersection(mask.pos);
+            for (int y = intersection.y; y < intersection.y + intersection.height; y++) {
+                for (int x = intersection.x; x < intersection.x + intersection.width; x++) {
+                    if (isMasked1.test(x, y) && isMasked2.test(x, y)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Calculate the union of this mask with another.
+     * @param mask a mask
+     * @return the union of the masks, or {@code null} if the union requires a mask larger than either of the pair
+     */
+    public ImageMask union(ImageMask mask) {
+        if (z.equals(mask.z) && c.equals(mask.c) && t.equals(mask.t)) {
+            if (pos.contains(mask.pos)) {
+                /* Can use this mask's position for the union of the two. */
+                final byte[] bitmask = copyBitmask(this.bitmask);
+                if (pos.equals(mask.pos)) {
+                    /* If same position then the packing is aligned so combine byte-by-byte. */
+                    for (int index = 0; index < bitmask.length; index++) {
+                        bitmask[index] |= mask.bitmask[index];
+                    }
+                } else {
+                    /* Different positions so combine bit-by-bit. */
+                    final BiPredicate<Integer, Integer> isMasked = mask.getMaskReader(z.orElse(1), c.orElse(1), t.orElse(1));
+                    for (int y = mask.pos.y; y < mask.pos.y + mask.pos.height; y++) {
+                        for (int x = mask.pos.x; x < mask.pos.x + mask.pos.width; x++) {
+                            if (isMasked.test(x, y)) {
+                                final int bitPosition = (x - pos.x) + (y - pos.y) * pos.width;
+                                final int bytePosition = bitPosition >> 3;
+                                final int bitRemainder = 7 - (bitPosition & 7);
+                                bitmask[bytePosition] |= bitmask[bytePosition] & 1 << bitRemainder;
+                            }
+                        }
+                    }
+                }
+                return new ImageMask(pos, z, c, t, bitmask);
+            } else if (mask.pos.contains(pos)) {
+                /* Combine this mask onto the other. */
+                return mask.union(this);
+            }
+        }
+        /* No efficient combination. */
+        return null;
+    }
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
@@ -28,7 +28,7 @@ import java.util.function.BiPredicate;
 /**
  * Represents a simple planar bitmask.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since v0.1.6
+ * @since v0.1.7
  */
 public class ImageMask implements Bitmask {
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/ImageMask.java
@@ -211,7 +211,7 @@ public class ImageMask implements Bitmask {
                                 final int bitPosition = (x - pos.x) + (y - pos.y) * pos.width;
                                 final int bytePosition = bitPosition >> 3;
                                 final int bitRemainder = 7 - (bitPosition & 7);
-                                bitmask[bytePosition] |= bitmask[bytePosition] & 1 << bitRemainder;
+                                bitmask[bytePosition] |= 1 << bitRemainder;
                             }
                         }
                     }

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
@@ -116,22 +116,17 @@ public class UnionMask implements Bitmask {
         for (final Bitmask maskNewAbstract : masks) {
             if (maskNewAbstract instanceof ImageMask) {
                 /* Where possible, combine masks into a single new one. */
-                boolean isAdded = false;
-                final ImageMask maskNewConcrete = (ImageMask) maskNewAbstract;
+                ImageMask maskNewConcrete = (ImageMask) maskNewAbstract;
                 final Iterator<ImageMask> masksConcreteIter = masksConcrete.iterator();
                 while (masksConcreteIter.hasNext()) {
                     final ImageMask maskOldConcrete = masksConcreteIter.next();
                     final ImageMask maskUnion = maskOldConcrete.union(maskNewConcrete);
                     if (maskUnion != null) {
                         masksConcreteIter.remove();
-                        masksConcrete.add(maskUnion);
-                        isAdded = true;
-                        break;
+                        maskNewConcrete = maskUnion;
                     }
                 }
-                if (!isAdded) {
-                    masksConcrete.add(maskNewConcrete);
-                }
+                masksConcrete.add(maskNewConcrete);
             } else {
                 masksAbstract.add(maskNewAbstract);
             }

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.mask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a mask that may combine multiple masks,
+ * as for the union of multiple {@link ome.model.roi.Mask}s in the same {@link ome.model.roi.Roi}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.6
+ */
+public class UnionMask implements Bitmask {
+
+    private final Collection<Bitmask> masks;
+
+    /**
+     * Construct a union mask from the given set of masks.
+     * @param masks the masks to combine
+     */
+    UnionMask(Collection<Bitmask> masks) {
+        this.masks = masks;
+    }
+
+    @Override
+    public boolean isSignificant(char dimension) {
+        return masks.stream().anyMatch(mask -> mask.isSignificant(dimension));
+    }
+
+    @Override
+    public BiPredicate<Integer, Integer> getMaskReader(int z, int c, int t) {
+        final List<BiPredicate<Integer, Integer>> applicableMasks = masks.stream()
+                .map(mask -> mask.getMaskReader(z, c, t)).filter(obj -> obj != null).collect(Collectors.toList());
+        return applicableMasks.isEmpty() ? null : (x, y) -> applicableMasks.stream().anyMatch(p -> p.test(x, y));
+    }
+
+    @Override
+    public int size() {
+        return masks.stream().map(Bitmask::size).reduce(0, Math::addExact);
+    }
+
+    /**
+     * Test if this mask overlaps another.
+     * @param mask a mask
+     * @return if this mask overlaps the given mask
+     */
+    public boolean isOverlap(ImageMask mask) {
+        for (final Bitmask myMask : masks) {
+            if (myMask instanceof ImageMask) {
+                if (mask.isOverlap((ImageMask) myMask)) {
+                    return true;
+                }
+            } else if (myMask instanceof UnionMask) {
+                if (((UnionMask) myMask).isOverlap(mask)) {
+                    return true;
+                }
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Test if this mask overlaps another.
+     * @param mask a mask
+     * @return if this mask overlaps the given mask
+     */
+    public boolean isOverlap(UnionMask mask) {
+        for (final Bitmask myMask : masks) {
+            if (myMask instanceof ImageMask) {
+                if (mask.isOverlap((ImageMask) myMask)) {
+                    return true;
+                }
+            } else if (myMask instanceof UnionMask) {
+                if (((UnionMask) myMask).isOverlap(mask)) {
+                    return true;
+                }
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Calculate the union of a set of masks.
+     * @param masks some masks
+     * @return the union of the masks
+     */
+    public static Bitmask union(Iterable<? extends Bitmask> masks) {
+        final List<Bitmask> masksAbstract = new ArrayList<>();
+        final List<ImageMask> masksConcrete = new ArrayList<>();
+        for (final Bitmask maskNewAbstract : masks) {
+            if (maskNewAbstract instanceof ImageMask) {
+                /* Where possible, combine masks into a single new one. */
+                boolean isAdded = false;
+                final ImageMask maskNewConcrete = (ImageMask) maskNewAbstract;
+                final Iterator<ImageMask> masksConcreteIter = masksConcrete.iterator();
+                while (masksConcreteIter.hasNext()) {
+                    final ImageMask maskOldConcrete = masksConcreteIter.next();
+                    final ImageMask maskUnion = maskOldConcrete.union(maskNewConcrete);
+                    if (maskUnion != null) {
+                        masksConcreteIter.remove();
+                        masksConcrete.add(maskUnion);
+                        isAdded = true;
+                        break;
+                    }
+                }
+                if (!isAdded) {
+                    masksConcrete.add(maskNewConcrete);
+                }
+            } else {
+                masksAbstract.add(maskNewAbstract);
+            }
+        }
+        final int maskCount = masksAbstract.size() + masksConcrete.size();
+        final List<Bitmask> union = new ArrayList<>(maskCount);
+        union.addAll(masksAbstract);
+        union.addAll(masksConcrete);
+        return maskCount == 1 ? union.get(0) : new UnionMask(union);
+    }
+}

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * Represents a mask that may combine multiple masks,
  * as for the union of multiple {@link ome.model.roi.Mask}s in the same {@link ome.model.roi.Roi}.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since v0.1.6
+ * @since v0.1.7
  */
 public class UnionMask implements Bitmask {
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/mask/UnionMask.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class UnionMask implements Bitmask {
 
-    private final Collection<Bitmask> masks;
+    final Collection<Bitmask> masks;
 
     /**
      * Construct a union mask from the given set of masks.

--- a/src/scripts/copy-masks.py
+++ b/src/scripts/copy-masks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Copy masks from one server to another.
+# author: m.t.b.carroll@dundee.ac.uk
+
+from omero.gateway import BlitzGateway
+from omero.model import ImageI, MaskI, RoiI
+from omero.rtypes import rstring
+from omero.sys import ParametersI
+
+image_id_src = 6001240
+image_id_dst = 5851
+
+idr = BlitzGateway(
+    "public", "public", host="idr.openmicroscopy.org", secure=True
+)
+local = BlitzGateway("user-1", "ome", host="localhost", secure=True)
+
+idr.connect()
+local.connect()
+
+query_service = idr.getQueryService()
+update_service = local.getUpdateService()
+
+query = "FROM Mask WHERE roi.image.id = :id"
+
+params = ParametersI()
+params.addId(image_id_src)
+
+count = 0
+
+for mask_src in query_service.findAllByQuery(query, params):
+    mask_dst = MaskI()
+    mask_dst.x = mask_src.x
+    mask_dst.y = mask_src.y
+    mask_dst.width = mask_src.width
+    mask_dst.height = mask_src.height
+    mask_dst.theZ = mask_src.theZ
+    mask_dst.theC = mask_src.theC
+    mask_dst.theT = mask_src.theT
+    mask_dst.bytes = mask_src.bytes
+    mask_dst.transform = mask_src.transform
+    roi_dst = RoiI()
+    roi_dst.description = rstring(
+        "created by copy-masks script for original mask #{}".format(
+            mask_src.id.val
+        )
+    )
+    roi_dst.image = ImageI(image_id_dst, False)
+    roi_dst.addShape(mask_dst)
+    update_service.saveObject(roi_dst)
+    count += 1
+
+idr._closeSession()
+local._closeSession()
+
+print(
+    "from image #{} to #{}, mask count = {}".format(
+        image_id_src, image_id_dst, count
+    )
+)

--- a/src/scripts/copy-masks.py
+++ b/src/scripts/copy-masks.py
@@ -56,6 +56,7 @@ for mask_src in query_service.findAllByQuery(query, params):
     mask_dst.theC = mask_src.theC
     mask_dst.theT = mask_src.theT
     mask_dst.bytes = mask_src.bytes
+    mask_dst.fillColor = mask_src.fillColor
     mask_dst.transform = mask_src.transform
     roi_dst = RoiI()
     roi_dst.description = rstring(

--- a/src/scripts/copy-masks.py
+++ b/src/scripts/copy-masks.py
@@ -28,7 +28,8 @@ from omero.sys import ParametersI
 import argparse
 
 parser = argparse.ArgumentParser(
-    description="copy masks from an image on one server to another")
+    description="copy masks from an image on one server to another"
+)
 parser.add_argument("--from-host", default="idr.openmicroscopy.org")
 parser.add_argument("--from-user", default="public")
 parser.add_argument("--from-pass", default="public")

--- a/src/scripts/copy-masks.py
+++ b/src/scripts/copy-masks.py
@@ -25,13 +25,25 @@ from omero.model import ImageI, MaskI, RoiI
 from omero.rtypes import rstring
 from omero.sys import ParametersI
 
-image_id_src = 6001240
-image_id_dst = 5851
+import argparse
 
-idr = BlitzGateway(
-    "public", "public", host="idr.openmicroscopy.org", secure=True
-)
-local = BlitzGateway("user-1", "ome", host="localhost", secure=True)
+parser = argparse.ArgumentParser(
+    description="copy masks from an image on one server to another")
+parser.add_argument("--from-host", default="idr.openmicroscopy.org")
+parser.add_argument("--from-user", default="public")
+parser.add_argument("--from-pass", default="public")
+parser.add_argument("--to-host", default="localhost")
+parser.add_argument("--to-user", default="root")
+parser.add_argument("--to-pass", default="omero")
+parser.add_argument("source_image", type=int, help="input image")
+parser.add_argument("target_image", type=int, help="output image")
+ns = parser.parse_args()
+
+image_id_src = ns.source_image
+image_id_dst = ns.target_image
+
+idr = BlitzGateway(ns.from_user, ns.from_pass, host=ns.from_host, secure=True)
+local = BlitzGateway(ns.to_user, ns.to_pass, host=ns.to_host, secure=True)
 
 idr.connect()
 local.connect()

--- a/src/scripts/overlapping-masks.py
+++ b/src/scripts/overlapping-masks.py
@@ -17,7 +17,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# Copy masks from one server to another.
+# Generate overlapping masks on an existing image.
 # author: m.t.b.carroll@dundee.ac.uk
 
 from omero.gateway import BlitzGateway

--- a/src/scripts/overlapping-masks.py
+++ b/src/scripts/overlapping-masks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Copy masks from one server to another.
+# author: m.t.b.carroll@dundee.ac.uk
+
+from omero.gateway import BlitzGateway
+from omero.model import MaskI, RoiI
+from omero.rtypes import rstring, rdouble
+from omero.sys import ParametersI
+
+import numpy as np
+
+import argparse
+
+parser = argparse.ArgumentParser(
+    description="generate fake masks that overlap"
+)
+parser.add_argument("--to-host", default="localhost")
+parser.add_argument("--to-user", default="root")
+parser.add_argument("--to-pass", default="omero")
+parser.add_argument("target_image", type=int, help="output image")
+ns = parser.parse_args()
+
+image_id_dst = ns.target_image
+
+local = BlitzGateway(ns.to_user, ns.to_pass, host=ns.to_host, secure=True)
+
+local.connect()
+
+query_service = local.getQueryService()
+update_service = local.getUpdateService()
+
+query = "FROM Image WHERE id = :id"
+
+params = ParametersI()
+params.addId(image_id_dst)
+
+count = 0
+image = query_service.findByQuery(query, params)
+
+
+def make_circle(h, w):
+    x = np.arange(0, w)
+    y = np.arange(0, h)
+    arr = np.zeros((y.size, x.size), dtype=bool)
+
+    cx = w // 2
+    cy = h // 2
+    r = min(w, h) // 2
+
+    mask = (x[np.newaxis, :] - cx) ** 2 + (y[:, np.newaxis] - cy) ** 2 < r ** 2
+    arr[mask] = 1
+    arr = np.packbits(arr)
+    return arr
+
+
+def make_mask(x, y, h, w):
+    mask = MaskI()
+    mask.x = rdouble(x)
+    mask.y = rdouble(y)
+    mask.height = rdouble(h)
+    mask.width = rdouble(w)
+    mask.bytes = make_circle(h, w)
+
+    roi = RoiI()
+    roi.description = rstring("created by overlapping-masks.py")
+    roi.addShape(mask)
+    roi.image = image
+    roi = update_service.saveAndReturnObject(roi)
+    print(f"Roi:{roi.id.val}")
+
+
+make_mask(20, 20, 40, 40)
+make_mask(30, 30, 50, 50)
+local._closeSession()

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryDataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryDataTest.java
@@ -21,9 +21,7 @@ package org.openmicroscopy.ms.zarr;
 
 import java.io.IOException;
 import java.util.zip.DataFormatException;
-import java.util.zip.Inflater;
 
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -38,27 +36,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author m.t.b.carroll@dundee.ac.uk
  */
 public class ZarrBinaryDataTest extends ZarrEndpointsTestBase {
-
-    /**
-     * Uncompress the given byte array.
-     * @param compressed a byte array
-     * @return the uncompressed bytes
-     * @throws DataFormatException unexpected
-     */
-    private static byte[] uncompress(byte[] compressed) throws DataFormatException {
-        final Inflater inflater = new Inflater();
-        inflater.setInput(compressed);
-        final Buffer uncompressed = Buffer.factory.buffer(2 * compressed.length);
-        final byte[] batch = new byte[8192];
-        int batchSize;
-        do {
-            batchSize = inflater.inflate(batch);
-            uncompressed.appendBytes(batch, 0, batchSize);
-        } while (batchSize > 0);
-        Assertions.assertFalse(inflater.needsDictionary());
-        inflater.end();
-        return uncompressed.getBytes();
-    }
 
     boolean isSomeChunkFitsWithin;
     boolean isSomeChunkOverlapsRight;

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryImageTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryImageTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Check that the binary data served from the microservice endpoints has the expected pixel values.
  * @author m.t.b.carroll@dundee.ac.uk
  */
-public class ZarrBinaryDataTest extends ZarrEndpointsTestBase {
+public class ZarrBinaryImageTest extends ZarrEndpointsImageTestBase {
 
     boolean isSomeChunkFitsWithin;
     boolean isSomeChunkOverlapsRight;

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryImageTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryImageTest.java
@@ -87,12 +87,15 @@ public class ZarrBinaryImageTest extends ZarrEndpointsImageTestBase {
     @MethodSource("provideGroupDetails")
     public void testZarrChunks(int resolution, String path, Double scale) throws DataFormatException, IOException {
         final JsonObject response = getResponseAsJson(0, path, ".zarray");
+        final JsonArray shape = response.getJsonArray("shape");
+        final int imageSizeX = shape.getInteger(4);
+        final int imageSizeY = shape.getInteger(3);
+        pixelBuffer.setResolutionLevel(resolution);
+        Assertions.assertEquals(pixelBuffer.getSizeX(), imageSizeX);
+        Assertions.assertEquals(pixelBuffer.getSizeY(), imageSizeY);
         final JsonArray chunks = response.getJsonArray("chunks");
         final int chunkSizeX = chunks.getInteger(4);
         final int chunkSizeY = chunks.getInteger(3);
-        pixelBuffer.setResolutionLevel(resolution);
-        final int imageSizeX = pixelBuffer.getSizeX();
-        final int imageSizeY = pixelBuffer.getSizeY();
         int chunkIndexY = 0;
         for (int y = 0; y < imageSizeY; y += chunkSizeY) {
             int chunkIndexX = 0;

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
@@ -121,6 +121,8 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
         Mockito.when(dao.getMaskIdsOfRoi(Mockito.eq(roi1.getId()))).thenReturn(ImmutableSortedSet.of(mask1.getId(), mask2.getId()));
         Mockito.when(dao.getMaskIdsOfRoi(Mockito.eq(roi2.getId()))).thenReturn(ImmutableSortedSet.of(mask3.getId()));
         Mockito.when(dao.getRoiIdsOfImage(Mockito.eq(image.getId()))).thenReturn(ImmutableSortedSet.of(roi1.getId(), roi2.getId()));
+        Mockito.when(dao.getRoiIdsWithMaskOfImage(Mockito.eq(image.getId())))
+        .thenReturn(ImmutableSortedSet.of(roi1.getId(), roi2.getId()));
         return dao;
     }
 

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import org.openmicroscopy.ms.zarr.mask.ImageMask;
+
+import ome.model.core.Image;
+import ome.model.core.Pixels;
+import ome.model.roi.Mask;
+import ome.model.roi.Roi;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.zip.DataFormatException;
+
+import com.google.common.collect.ImmutableSortedSet;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * Check that the binary data served from the microservice endpoints has the expected mask values.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.7
+ */
+public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
+
+    private Image image;
+    private Roi roi1, roi2;
+    private Mask mask1, mask2, mask3;
+    private BiPredicate<Integer, Integer> isMasked1, isMasked2, isMasked3;
+
+    /**
+     * Create an test image with masks.
+     */
+    @BeforeAll
+    private void maskSetup() {
+        pixelBuffer.setResolutionLevel(pixelBuffer.getResolutionLevels() - 1);
+        final int size = (int) Math.sqrt(pixelBuffer.getSizeX() * pixelBuffer.getSizeY() >> 3) & -4;
+        final byte[] bitmask1 = new byte[size * size];
+        final byte[] bitmask2 = new byte[size * size >> 2];
+        final byte[] bitmask3 = new byte[size * size >> 2];
+        int factor = 3;
+        for (final byte[] bitmask : new byte[][] {bitmask1, bitmask2, bitmask3}) {
+            for (int index = 0; index < bitmask.length; index += factor) {
+                bitmask[index] = -1;
+            }
+            factor += 2;
+        }
+        long id = 0;
+        mask1 = new Mask(++id, true);
+        mask1.setX(0.0);
+        mask1.setY(0.0);
+        mask1.setWidth((double) (size << 1));
+        mask1.setHeight((double) (size << 2));
+        mask1.setBytes(bitmask1);
+        mask2 = new Mask(++id, true);
+        mask2.setX(0.0);
+        mask2.setY(0.0);
+        mask2.setWidth((double) (size << 1));
+        mask2.setHeight((double) (size));
+        mask2.setBytes(bitmask2);
+        mask3 = new Mask(++id, true);
+        mask3.setX(mask1.getWidth() / 2);
+        mask3.setY(mask1.getHeight() / 2);
+        mask3.setWidth((double) (size));
+        mask3.setHeight((double) (size << 1));
+        mask3.setBytes(bitmask3);
+        roi1 = new Roi(++id, true);
+        roi2 = new Roi(++id, true);
+        image = new Image(++id, true);
+        roi1.addShape(mask1);
+        roi1.addShape(mask2);
+        roi2.addShape(mask3);
+        image.addRoiSet(Arrays.asList(roi1, roi2));
+        isMasked1 = new ImageMask(mask1).getMaskReader(1, 1, 1);
+        isMasked2 = new ImageMask(mask2).getMaskReader(1, 1, 1);
+        isMasked3 = new ImageMask(mask3).getMaskReader(1, 1, 1);
+    }
+
+    @Override
+    protected OmeroDao daoSetup() {
+        final Pixels pixels = constructMockPixels();
+        final OmeroDao dao = Mockito.mock(OmeroDao.class);
+        Mockito.when(dao.getPixels(Mockito.eq(image.getId()))).thenReturn(pixels);
+        Mockito.when(dao.getMask(Mockito.eq(mask1.getId()))).thenReturn(mask1);
+        Mockito.when(dao.getMask(Mockito.eq(mask2.getId()))).thenReturn(mask2);
+        Mockito.when(dao.getMask(Mockito.eq(mask3.getId()))).thenReturn(mask3);
+        Mockito.when(dao.getRoi(Mockito.eq(roi1.getId()))).thenReturn(roi1);
+        Mockito.when(dao.getRoi(Mockito.eq(roi2.getId()))).thenReturn(roi2);
+        Mockito.when(dao.getMaskCountOfRoi(Mockito.eq(roi1.getId()))).thenReturn((long) roi1.sizeOfShapes());
+        Mockito.when(dao.getMaskCountOfRoi(Mockito.eq(roi2.getId()))).thenReturn((long) roi2.sizeOfShapes());
+        Mockito.when(dao.getRoiCountOfImage(Mockito.eq(image.getId()))).thenReturn((long) image.sizeOfRois());
+        Mockito.when(dao.getMaskIdsOfRoi(Mockito.eq(roi1.getId()))).thenReturn(ImmutableSortedSet.of(mask1.getId(), mask2.getId()));
+        Mockito.when(dao.getMaskIdsOfRoi(Mockito.eq(roi2.getId()))).thenReturn(ImmutableSortedSet.of(mask3.getId()));
+        Mockito.when(dao.getRoiIdsOfImage(Mockito.eq(image.getId()))).thenReturn(ImmutableSortedSet.of(roi1.getId(), roi2.getId()));
+        return dao;
+    }
+
+    /**
+     * Check that the chunks for a split mask from the microservice are as expected.
+     * @throws DataFormatException unexpected
+     * @throws IOException unexpected
+     */
+    @Test
+    public void testMaskChunks() throws DataFormatException, IOException {
+        final Set<Byte> seenIsMasked = new HashSet<>();
+        final JsonObject response = getResponseAsJson(image.getId(), "masks", roi1.getId(), ".zarray");
+        final JsonArray shape = response.getJsonArray("shape");
+        final int maskSizeX = shape.getInteger(4);
+        final int maskSizeY = shape.getInteger(3);
+        Assertions.assertEquals(pixelBuffer.getSizeX(), maskSizeX);
+        Assertions.assertEquals(pixelBuffer.getSizeY(), maskSizeY);
+        final JsonArray chunks = response.getJsonArray("chunks");
+        final int chunkSizeX = chunks.getInteger(4);
+        final int chunkSizeY = chunks.getInteger(3);
+        int chunkIndexY = 0;
+        for (int y = 0; y < maskSizeY; y += chunkSizeY) {
+            int chunkIndexX = 0;
+            for (int x = 0; x < maskSizeX; x += chunkSizeX) {
+                mockSetup();
+                final byte[] chunkZipped =
+                        getResponseAsBytes(image.getId(), "masks", roi1.getId(), 0, 0, 0, chunkIndexY, chunkIndexX);
+                final byte[] chunk = uncompress(chunkZipped);
+                for (int cx = 0; cx < chunkSizeX; cx++) {
+                    for (int cy = 0; cy < chunkSizeY; cy++) {
+                        final boolean isMasked = isMasked1.test(x + cx, y + cy) || isMasked2.test(x + cx, y + cy);
+                        final int index = chunkSizeX * cy + cx;
+                        if (isMasked) {
+                            Assertions.assertNotEquals(0, chunk[index]);
+                        } else {
+                            Assertions.assertEquals(0, chunk[index]);
+                        }
+                        seenIsMasked.add(chunk[index]);
+                    }
+                }
+                chunkIndexX++;
+            }
+            chunkIndexY++;
+        }
+        Assertions.assertEquals(2, seenIsMasked.size());
+    }
+
+    /**
+     * Check that the chunks for a labeled mask from the microservice are as expected.
+     * @throws DataFormatException unexpected
+     * @throws IOException unexpected
+     */
+    @Test
+    public void testLabeledMaskChunks() throws DataFormatException, IOException {
+        final Set<Long> seenLabels = new HashSet<>();
+        final JsonObject response = getResponseAsJson(image.getId(), "masks", "labeled", ".zarray");
+        final JsonArray shape = response.getJsonArray("shape");
+        final int maskSizeX = shape.getInteger(4);
+        final int maskSizeY = shape.getInteger(3);
+        Assertions.assertEquals(pixelBuffer.getSizeX(), maskSizeX);
+        Assertions.assertEquals(pixelBuffer.getSizeY(), maskSizeY);
+        final JsonArray chunks = response.getJsonArray("chunks");
+        final int chunkSizeX = chunks.getInteger(4);
+        final int chunkSizeY = chunks.getInteger(3);
+        int chunkIndexY = 0;
+        for (int y = 0; y < maskSizeY; y += chunkSizeY) {
+            int chunkIndexX = 0;
+            for (int x = 0; x < maskSizeX; x += chunkSizeX) {
+                mockSetup();
+                final byte[] chunkZipped = getResponseAsBytes(image.getId(), "masks", "labeled", 0, 0, 0, chunkIndexY, chunkIndexX);
+                final ByteBuffer chunk = ByteBuffer.wrap(uncompress(chunkZipped));
+                for (int cx = 0; cx < chunkSizeX; cx++) {
+                    for (int cy = 0; cy < chunkSizeY; cy++) {
+                        final boolean isRoi1 = isMasked1.test(x + cx, y + cy) || isMasked2.test(x + cx, y + cy);
+                        final boolean isRoi2 = isMasked3.test(x + cx, y + cy);
+                        final long expectedLabel;
+                        if (isRoi1) {
+                            expectedLabel = isRoi2 ? ZarrEndpointsTestBase.MASK_OVERLAP_VALUE : roi1.getId();
+                        } else {
+                            expectedLabel = isRoi2 ? roi2.getId() : 0;
+                        }
+                        final int index = Long.BYTES * (chunkSizeX * cy + cx);
+                        final long actualLabel = chunk.getLong(index);
+                        Assertions.assertEquals(expectedLabel, actualLabel);
+                        seenLabels.add(actualLabel);
+                    }
+                }
+                chunkIndexX++;
+            }
+            chunkIndexY++;
+        }
+        Assertions.assertEquals(4, seenLabels.size());
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsImageTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsImageTestBase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr;
+
+import ome.model.core.Pixels;
+
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
+
+import org.mockito.Mockito;
+import org.openmicroscopy.ms.zarr.OmeroDao;
+
+/**
+ * Base class that sets up a simple DAO that always fetches the mock pixels object.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.7
+ */
+public abstract class ZarrEndpointsImageTestBase extends ZarrEndpointsTestBase {
+
+    @Override
+    protected OmeroDao daoSetup() {
+        final Pixels pixels = constructMockPixels();
+        final Query query = Mockito.mock(Query.class);
+        final Session session = Mockito.mock(Session.class);
+        final SessionFactory sessionFactory = Mockito.mock(SessionFactory.class);
+        Mockito.when(query.uniqueResult()).thenReturn(pixels);
+        Mockito.when(query.setParameter(Mockito.eq(0), Mockito.anyLong())).thenReturn(query);
+        Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(query);
+        Mockito.when(sessionFactory.openSession()).thenReturn(session);
+        return new OmeroDao(sessionFactory);
+    }
+}

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -75,6 +75,8 @@ public abstract class ZarrEndpointsTestBase {
     protected static final String MEDIA_TYPE_BINARY = "application/octet-stream";
     protected static final String MEDIA_TYPE_JSON = "application/json; charset=utf-8";
 
+    protected static final long MASK_OVERLAP_VALUE = -1;
+
     protected static final String URI_PATH_PREFIX = "test";
 
     protected PixelBuffer pixelBuffer = new PixelBufferFake();
@@ -177,7 +179,9 @@ public abstract class ZarrEndpointsTestBase {
         Mockito.when(httpRequest.method()).thenReturn(HttpMethod.GET);
         Mockito.when(httpRequest.response()).thenReturn(httpResponse);
         final String URI = URI_PATH_PREFIX + '/' + Configuration.PLACEHOLDER_IMAGE_ID + '/';
-        final Map<String, String> settings = ImmutableMap.of(Configuration.CONF_NET_PATH_IMAGE, URI);
+        final Map<String, String> settings = ImmutableMap.of(
+                Configuration.CONF_MASK_OVERLAP_VALUE, Long.toString(MASK_OVERLAP_VALUE),
+                Configuration.CONF_NET_PATH_IMAGE, URI);
         final Configuration configuration = new Configuration(settings);
         final OmeroDao dao = daoSetup();
         final PixelBufferCache cache = new PixelBufferCache(configuration, pixelsServiceMock, dao);

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrEndpointsTestBase.java
@@ -181,6 +181,7 @@ public abstract class ZarrEndpointsTestBase {
         final String URI = URI_PATH_PREFIX + '/' + Configuration.PLACEHOLDER_IMAGE_ID + '/';
         final Map<String, String> settings = ImmutableMap.of(
                 Configuration.CONF_MASK_OVERLAP_VALUE, Long.toString(MASK_OVERLAP_VALUE),
+                Configuration.CONF_MASK_SPLIT_ENABLE, Boolean.toString(true), // Non-default to enable tests
                 Configuration.CONF_NET_PATH_IMAGE, URI);
         final Configuration configuration = new Configuration(settings);
         final OmeroDao dao = daoSetup();

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Check that the metadata served from the microservice endpoints are of the expected form.
  * @author m.t.b.carroll@dundee.ac.uk
  */
-public class ZarrMetadataTest extends ZarrEndpointsTestBase {
+public class ZarrMetadataTest extends ZarrEndpointsImageTestBase {
 
     private final List<Dimension> resolutionSizes = new ArrayList<>();
 

--- a/src/test/java/org/openmicroscopy/ms/zarr/mask/TestUnionMasks.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/mask/TestUnionMasks.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.ms.zarr.mask;
+
+import java.awt.Rectangle;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test that unions of bitmasks work correctly.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since v0.1.7
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestUnionMasks {
+
+    private static BiPredicate<Integer, Integer> ALWAYS_NOTHING = getMaskPredicate(new Rectangle(), 0, 0);
+
+    private final Set<Integer> maskCountsObserved = new HashSet<>();
+    private final Multimap<Character, Boolean> dimensionSignificancesObserved = HashMultimap.create();
+
+    /**
+     * Construct a mask predicate that has pixels set at a regular interval.
+     * @param pos the position of the mask
+     * @param xInterval the horizontal distance from one set pixel to the next
+     * @param yInterval the vertical distance from one set pixel to the next
+     * @return a new mask predicate
+     */
+    private static BiPredicate<Integer, Integer> getMaskPredicate(Rectangle pos, int xInterval, int yInterval) {
+        return new BiPredicate<Integer, Integer>() {
+            @Override
+            public boolean test(Integer x, Integer y) {
+                return pos.contains(x, y) && (x - pos.x) % xInterval == 0 && (y - pos.y) % yInterval == 0;
+            }
+        };
+    }
+
+    /**
+     * Construct a mask whose bitmask is set according to a predicate.
+     * @param pos the position of the mask
+     * @param z the <em>Z</em> plane of the mask, or {@code null} if it extends to all <em>Z</em> planes
+     * @param c the <em>C</em> plane of the mask, or {@code null} if it extends to all <em>C</em> planes
+     * @param t the <em>T</em> plane of the mask, or {@code null} if it extends to all <em>T</em> planes
+     * @param maskPredicate the predicate defining the mask's pixel data
+     * @return a new mask
+     */
+    private static ImageMask constructMask(Rectangle pos, Integer z, Integer c, Integer t,
+            BiPredicate<Integer, Integer> maskPredicate) {
+        final byte[] bitmask = new byte[pos.width * pos.height + 7 >> 3];
+        for (int y = pos.y; y < pos.y + pos.height; y++) {
+            for (int x = pos.x; x < pos.x + pos.width; x++) {
+                if (maskPredicate.test(x, y)) {
+                    final int bitPosition = (x - pos.x) + (y - pos.y) * pos.width;
+                    final int bytePosition = bitPosition >> 3;
+                    final int bitRemainder = 7 - (bitPosition & 7);
+                    bitmask[bytePosition] |= 1 << bitRemainder;
+                }
+            }
+        }
+        return new ImageMask(pos.x, pos.y, pos.width, pos.height, z, c, t, bitmask);
+    }
+
+    /**
+     * Test the union of three masks.
+     * @param x1 the <em>X</em> offset of the second mask with respect to the first
+     * @param z1 the <em>Z</em> plane of the second mask, or {@code null} if it extends to all <em>Z</em> planes
+     * @param c1 the <em>C</em> plane of the second mask, or {@code null} if it extends to all <em>C</em> planes
+     * @param t1 the <em>T</em> plane of the second mask, or {@code null} if it extends to all <em>T</em> planes
+     * @param x2 the <em>X</em> offset of the third mask with respect to the first
+     * @param z2 the <em>Z</em> plane of the third mask, or {@code null} if it extends to all <em>Z</em> planes
+     * @param c2 the <em>C</em> plane of the third mask, or {@code null} if it extends to all <em>C</em> planes
+     * @param t2 the <em>T</em> plane of the third mask, or {@code null} if it extends to all <em>T</em> planes
+     * @param isReverse if the mask union operation should be performed in the order of third, second, first
+     */
+    @ParameterizedTest
+    @MethodSource("provideMaskPlacements")
+    public void testCombiningMasks(int x1, Integer z1, Integer c1, Integer t1, int x2, Integer z2, Integer c2, Integer t2,
+            boolean isReverse) {
+        /* Define the three masks. */
+        final Rectangle pos0 = new Rectangle(0, 0, 80, 80);
+        final Rectangle pos1 = new Rectangle(x1, 20, 35, 35);
+        final Rectangle pos2 = new Rectangle(x2, 30, 40, 25);
+        final BiPredicate<Integer, Integer> isMasked0 = getMaskPredicate(pos0, 11, 13);
+        final BiPredicate<Integer, Integer> isMasked1 = getMaskPredicate(pos1, 3, 7);
+        final BiPredicate<Integer, Integer> isMasked2 = getMaskPredicate(pos2, 5, 9);
+        final Bitmask mask0 = constructMask(pos0, null, null, null, isMasked0);
+        final Bitmask mask1 = constructMask(pos1, z1, c1, t1, isMasked1);
+        final Bitmask mask2 = constructMask(pos2, z2, c2, t2, isMasked2);
+        /* Determine how many masks should be required for the union. */
+        int expectedMaskCount = 3;
+        if (z1 == null && c1 == null && t1 == null && pos0.contains(pos1)) {
+            expectedMaskCount--;
+        }
+        if (z2 == null && c2 == null && t2 == null && pos0.contains(pos2)) {
+            expectedMaskCount--;
+        }
+        /* Determine the union mask. */
+        final List<Bitmask> masks = Lists.newArrayList(mask0, mask1, mask2);
+        if (isReverse) {
+            Collections.reverse(masks);
+        }
+        final Bitmask unionMask = UnionMask.union(masks);
+        /* Check that the union mask has the expected properties. */
+        if (expectedMaskCount == 1) {
+            /* Should be just as the first mask except in pixel data. */
+            Assertions.assertTrue(unionMask instanceof ImageMask);
+            Assertions.assertEquals(pos0, ((ImageMask) unionMask).pos);
+            Assertions.assertEquals(mask0.size(), unionMask.size());
+        } else {
+            /* Should be larger than the first mask. */
+            Assertions.assertTrue(unionMask instanceof UnionMask);
+            Assertions.assertEquals(expectedMaskCount, ((UnionMask) unionMask).masks.size());
+            Assertions.assertTrue(mask0.size() < unionMask.size());
+        }
+        /* Check that the significance of dimensions is accurately reported so that space can be saved. */
+        Assertions.assertNotEquals(z1 == null && z2 == null, unionMask.isSignificant('Z'));
+        Assertions.assertNotEquals(c1 == null && c2 == null, unionMask.isSignificant('C'));
+        Assertions.assertNotEquals(t1 == null && t2 == null, unionMask.isSignificant('T'));
+        /* Check that the pixel data is as one would expect from a union of the masks. */
+        final Rectangle pos012 = pos0.union(pos1.union(pos2));
+        for (int t = 0; t < 2; t++) {
+            for (int c = 0; c < 2; c++) {
+                for (int z = 0; z < 2; z++) {
+                    final boolean isMask1 = (z1 == null || z1 == z) && (c1 == null || c1 == c) && (t1 == null || t1 == t);
+                    final boolean isMask2 = (z2 == null || z2 == z) && (c2 == null || c2 == c) && (t2 == null || t2 == t);
+                    final BiPredicate<Integer, Integer> isMaskedCurrent0 = isMasked0;
+                    final BiPredicate<Integer, Integer> isMaskedCurrent1 = isMask1 ? isMasked1 : ALWAYS_NOTHING;
+                    final BiPredicate<Integer, Integer> isMaskedCurrent2 = isMask2 ? isMasked2 : ALWAYS_NOTHING;
+                    final BiPredicate<Integer, Integer> isMasked = unionMask.getMaskReader(z, c, t);
+                    for (int y = pos012.y; y < pos012.y + pos012.height; y++) {
+                        for (int x = pos012.x; x < pos012.x + pos012.width; x++) {
+                            final boolean expected =
+                                    isMaskedCurrent0.test(x, y) || isMaskedCurrent1.test(x, y) || isMaskedCurrent2.test(x, y);
+                            final boolean actual = isMasked.test(x, y);
+                            Assertions.assertEquals(expected, actual);
+                        }
+                    }
+                }
+            }
+        }
+        /* Note observations. */
+        maskCountsObserved.add(expectedMaskCount);
+        for (final char dimension : "ZCT".toCharArray()) {
+            dimensionSignificancesObserved.put(dimension, unionMask.isSignificant(dimension));
+        }
+    }
+
+    /**
+     * @return mask placements for
+     * {@link #testCombiningMasks(int, Integer, Integer, Integer, int, Integer, Integer, Integer, boolean)}
+     */
+    private static Stream<Arguments> provideMaskPlacements() {
+        final Stream.Builder<Arguments> arguments = Stream.builder();
+        final List<Integer> planes = Arrays.asList(null, 0, 1);
+        for (final boolean isReverse : new boolean[] {false, true}) {
+            for (final Integer t1 : planes) {
+                for (final Integer c1 : planes) {
+                    for (final Integer z1 : planes) {
+                        if ((z1 == null ? 1 : 0) + (c1 == null ? 1 : 0) + (t1 == null ? 1 : 0) == 1) {
+                            /* To save time, skip cases with two of Z, C, T set. */
+                            continue;
+                        }
+                        for (final Integer t2 : planes.subList(0, 2)) {
+                            for (final Integer c2 : planes.subList(0, 2)) {
+                                for (final Integer z2 : planes.subList(0, 2)) {
+                                    if ((z2 == null ? 1 : 0) + (c2 == null ? 1 : 0) + (t2 == null ? 1 : 0) == 1) {
+                                        /* To save time, skip cases with two of Z, C, T set. */
+                                        continue;
+                                    }
+                                    for (int x1 = -1; x1 < 2; x1++) {
+                                        for (int x2 = -1; x2 < 2; x2++) {
+                                            arguments.add(Arguments.of(x1, z1, c1, t1, x2, z2, c2, t2, isReverse));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return arguments.build();
+    }
+
+    /**
+     * Reset the observation notes ready for a test run.
+     */
+    @BeforeAll
+    public void clearObservations() {
+        maskCountsObserved.clear();
+        dimensionSignificancesObserved.clear();
+    }
+
+    /**
+     * After a test run check that the coverage was as intended.
+     */
+    @AfterAll
+    public void checkObservations() {
+        Assertions.assertEquals(3, maskCountsObserved.size());
+        Assertions.assertEquals(6, dimensionSignificancesObserved.size());
+    }
+}


### PR DESCRIPTION
For a split view, within the main image directory, this PR offers a `masks/` folder with subfolders named for the ROI IDs because masks within the same ROI are combined into one. If the ROIs do not overlap then `masks/labeled/` is also offered, the "pixel values" being the ROI IDs for this initial version.

As with the main image Zarr, the masks can also be fetched via `wget -r -l0` though one might afterward want to run, `find . -name index.html -exec rm {} +`. Mask endpoints should respect the setting for `omero.ms.zarr.folder.layout`.

Although the code should perform reasonably already, clarity is not much sacrificed in that pursuit. In moving nearer production, various operations could be optimized: for example, the DAO could directly offer the most appropriate query, more opportunities could be taken to efficiently operate upon data byte-wise rather than bit-wise, or perhaps 4xx could be promptly offered for empty chunks of sparse data.

This is a draft PR because the code handles enough cases that additional unit testing is warranted; as it is, one will plausibly find bugs. Further, it focuses on getting the binary data right in aiming to get the trickiest aspects solved first. The offered metadata is scanty and could certainly be expanded, happy to roll any critical omissions into this PR.

The division in `Bitmask` between `ImageMask` and `UnionMask` could be arranged better in OOP but it suffices for the meantime.

Further work could be to add features offered by the CLI plugin.

*Update:* `omero.ms.zarr.mask.overlap.value` now enables overlapping labeled masks, just set the property with the "overlap" value.