### PR TITLE
Rename labels

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -33,19 +33,19 @@ for public re-use.
     │   └── t.c.z.y.x         # a "chunk coordinate", where the maximum coordinate
     │                         # will be `dimension_size / chunk_size`.
     │
-    └── masks
+    └── labels
         │
-        ├── .zgroup           # The masks group is a container which holds a list
-        ├── .zattrs           # of masks to make the objects easily discoverable,
-        │                     # All masks will be listed in `.zattrs` e.g. `{ "masks": [ "original/0" ] }`
-        │                     # Each dimension of the mask `(t, c, z, y, x)` should be either the same as the
-        │                     # corresponding dimension of the image, or `1` if that dimension of the mask
+        ├── .zgroup           # The labels group is a container which holds a list
+        ├── .zattrs           # of labels to make the objects easily discoverable,
+        │                     # All labels will be listed in `.zattrs` e.g. `{ "labels": [ "original/0" ] }`
+        │                     # Each dimension of the label `(t, c, z, y, x)` should be either the same as the
+        │                     # corresponding dimension of the image, or `1` if that dimension of the label
         │                     # is irrelevant.
         │
         └── original          # Intermediate folders are permitted but not necessary
             │                 # and currently contain no extra metadata.
             └── 0
-                ├── .zarray   # Each mask itself is a 5D array matching the highest resolution
+                ├── .zarray   # Each label itself is a 5D array matching the highest resolution
                 └── .zattrs   # of the related image and has an extra key, "color", with display information.
 
 
@@ -113,20 +113,20 @@ can be found under the "omero" key in the group-level metadata:
 See https://docs.openmicroscopy.org/omero/5.6.1/developers/Web/WebGateway.html#imgdata
 for more information.
 
-### "masks"
+### "labels"
 
-The special group "masks" found under an image Zarr contains the key `masks` containing
-the paths to mask objects which can be found underneath the group:
+The special group "labels" found under an image Zarr contains the key `labels` containing
+the paths to label objects which can be found underneath the group:
 
 ```
 {
-  "masks": [
+  "labels": [
     "orphaned/0"
   ]
 }
 ```
 
-Unlisted groups MAY be masks.
+Unlisted groups MAY be labels.
 
 ### "color"
 
@@ -143,7 +143,7 @@ the value is an RGBA color (4 byte, `0-255` per channel) for representing the ob
 ```
 ### "image"
 
-The `image` key is an optional dictionary which contains information on the image the mask is associated with.
+The `image` key is an optional dictionary which contains information on the image the label is associated with.
 If included it must include a key `array` whose value that is either:
 - A relative path to a Zarr image array, for example:
     ```
@@ -153,7 +153,7 @@ If included it must include a key `array` whose value that is either:
       }
     }
     ```
-- A URL to a Zarr image array (use this if the mask is stored seperately from the image Zarr), for example:
+- A URL to a Zarr image array (use this if the label is stored seperately from the image Zarr), for example:
     ```
     {
       "image": {
@@ -166,7 +166,8 @@ If included it must include a key `array` whose value that is either:
 
 | Revision   | Date         | Description                                |
 | ---------- | ------------ | ------------------------------------------ |
-| 0.1.3      | 2020-07-07   | Add mask metadata                          |
+| 0.1.3      | 2020-08-18   | Rename masks as labels                     |
+| 0.1.3-dev1 | 2020-07-07   | Add mask metadata                          |
 | 0.1.2      | 2020-05-07   | Add description of "omero" metadata        |
 | 0.1.1      | 2020-05-06   | Add info on the ordering of resolutions    |
 | 0.1.0      | 2020-04-20   | First version for internal demo            |

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -95,7 +95,17 @@ public class RequestHandlerForImage implements HttpHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandlerForImage.class);
 
-    private static final String DEFAULT_LABEL_NAME = "0";  // See omero-cli-zarr
+    public static final String DEFAULT_LABEL_NAME = "0";  // See omero-cli-zarr
+
+    /**
+     * Key (i.e. path) to the group containing the label arrays.
+     */
+    public static final String LABEL_GROUP = "labels";  // See omero-cli-zarr
+
+    /**
+     * Key (i.e. JSON key) to the metadata for the label arrays.
+     */
+    public static final String LABEL_KEY = LABEL_GROUP;
 
     /**
      * Contains the dimensionality of an image.
@@ -362,24 +372,24 @@ public class RequestHandlerForImage implements HttpHandler {
         this.patternForImageDir = Pattern.compile(path);
         this.patternForImageGroupDir = Pattern.compile(path + "(\\d+)/");
         this.patternForImageChunkDir = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)/");
-        this.patternForImageMasksDir = Pattern.compile(path + "masks/");
-        this.patternForMaskDir = Pattern.compile(path + "masks/(\\d+)/");
-        this.patternForMaskChunkDir = Pattern.compile(path + "masks/(\\d+)/(\\d+([/.]\\d+)*)/");
-        this.patternForMaskLabeledDir = Pattern.compile(path + "masks/labell?ed/");
-        this.patternForMaskLabeledChunkDir = Pattern.compile(path + "masks/labell?ed/(\\d+([/.]\\d+)*)/");
+        this.patternForImageMasksDir = Pattern.compile(path + LABEL_GROUP + "/");
+        this.patternForMaskDir = Pattern.compile(path + LABEL_GROUP + "/(\\d+)/");
+        this.patternForMaskChunkDir = Pattern.compile(path + LABEL_GROUP + "/(\\d+)/(\\d+([/.]\\d+)*)/");
+        this.patternForMaskLabeledDir = Pattern.compile(path + LABEL_GROUP + "/" + DEFAULT_LABEL_NAME + "/");
+        this.patternForMaskLabeledChunkDir = Pattern.compile(path + LABEL_GROUP + "/" + DEFAULT_LABEL_NAME + "/(\\d+([/.]\\d+)*)/");
 
         this.patternForImageGroup = Pattern.compile(path + "\\.zgroup");
         this.patternForImageAttrs = Pattern.compile(path + "\\.zattrs");
-        this.patternForImageMasksGroup = Pattern.compile(path + "masks/\\.zgroup");
-        this.patternForImageMasksAttrs = Pattern.compile(path + "masks/\\.zattrs");
-        this.patternForMaskAttrs = Pattern.compile(path + "masks/(\\d+)/\\.zattrs");
-        this.patternForMaskLabeledAttrs = Pattern.compile(path + "masks/labell?ed/\\.zattrs");
+        this.patternForImageMasksGroup = Pattern.compile(path + LABEL_GROUP + "/\\.zgroup");
+        this.patternForImageMasksAttrs = Pattern.compile(path + LABEL_GROUP + "/\\.zattrs");
+        this.patternForMaskAttrs = Pattern.compile(path + LABEL_GROUP + "/(\\d+)/\\.zattrs");
+        this.patternForMaskLabeledAttrs = Pattern.compile(path + LABEL_GROUP + "/" + DEFAULT_LABEL_NAME + "/\\.zattrs");
         this.patternForImageArray = Pattern.compile(path + "(\\d+)/\\.zarray");
-        this.patternForMaskArray = Pattern.compile(path + "masks/(\\d+)/\\.zarray");
-        this.patternForMaskLabeledArray = Pattern.compile(path + "masks/labell?ed/\\.zarray");
+        this.patternForMaskArray = Pattern.compile(path + LABEL_GROUP + "/(\\d+)/\\.zarray");
+        this.patternForMaskLabeledArray = Pattern.compile(path + LABEL_GROUP + "/" + DEFAULT_LABEL_NAME + "/\\.zarray");
         this.patternForImageChunk = Pattern.compile(path + "(\\d+)/(\\d+([/.]\\d+)*)");
-        this.patternForMaskChunk = Pattern.compile(path + "masks/(\\d+)/(\\d+([/.]\\d+)*)");
-        this.patternForMaskLabeledChunk = Pattern.compile(path + "masks/labell?ed/(\\d+([/.]\\d+)*)");
+        this.patternForMaskChunk = Pattern.compile(path + LABEL_GROUP + "/(\\d+)/(\\d+([/.]\\d+)*)");
+        this.patternForMaskLabeledChunk = Pattern.compile(path + LABEL_GROUP + "/" + DEFAULT_LABEL_NAME + "/(\\d+([/.]\\d+)*)");
     }
 
     /**
@@ -662,7 +672,7 @@ public class RequestHandlerForImage implements HttpHandler {
         contents.add(".zgroup");
         for (final long roiId : omeroDao.getRoiIdsOfImage(imageId)) {
             if (omeroDao.getMaskCountOfRoi(roiId) > 0) {
-                contents.add("masks/");
+                contents.add(LABEL_GROUP + "/");
                 break;
             }
         }
@@ -1151,7 +1161,7 @@ public class RequestHandlerForImage implements HttpHandler {
         }
         /* package data for client */
         final Map<String, Object> result = new HashMap<>();
-        result.put("masks", masks);
+        result.put(LABEL_KEY, masks);
         respondWithJson(response, new JsonObject(result));
     }
 

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -95,6 +95,8 @@ public class RequestHandlerForImage implements HttpHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandlerForImage.class);
 
+    private static final String DEFAULT_LABEL_NAME = "0";  // See omero-cli-zarr
+
     /**
      * Contains the dimensionality of an image.
      * @author m.t.b.carroll@dundee.ac.uk
@@ -763,7 +765,7 @@ public class RequestHandlerForImage implements HttpHandler {
         final ImmutableList.Builder<String> contents = ImmutableList.builder();
         contents.add(".zattrs");
         if (labeledMasks != null) {
-            contents.add("labeled/");
+            contents.add(DEFAULT_LABEL_NAME);
         }
         if (isSplitMasksEnabled) {
             for (long roiId : roiIdsWithMask) {
@@ -1140,7 +1142,7 @@ public class RequestHandlerForImage implements HttpHandler {
         }
         final List<String> masks = new ArrayList<>(roiIdsWithMask.size() + 1);
         if (labeledMasks != null) {
-            masks.add("labeled");
+            masks.add(DEFAULT_LABEL_NAME);
         }
         if (isSplitMasksEnabled) {
             for (final long roiId : roiIdsWithMask) {

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -775,7 +775,7 @@ public class RequestHandlerForImage implements HttpHandler {
         final ImmutableList.Builder<String> contents = ImmutableList.builder();
         contents.add(".zattrs");
         if (labeledMasks != null) {
-            contents.add(DEFAULT_LABEL_NAME);
+            contents.add(DEFAULT_LABEL_NAME + "/");
         }
         if (isSplitMasksEnabled) {
             for (long roiId : roiIdsWithMask) {

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
@@ -21,6 +21,7 @@ package org.openmicroscopy.ms.zarr;
 
 import org.openmicroscopy.ms.zarr.mask.ImageMask;
 import static org.openmicroscopy.ms.zarr.RequestHandlerForImage.DEFAULT_LABEL_NAME;
+import static org.openmicroscopy.ms.zarr.RequestHandlerForImage.LABEL_GROUP;
 
 import ome.model.core.Image;
 import ome.model.core.Pixels;
@@ -135,7 +136,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
     @Test
     public void testMaskChunks() throws DataFormatException, IOException {
         final Set<Byte> seenIsMasked = new HashSet<>();
-        final JsonObject response = getResponseAsJson(image.getId(), "masks", roi1.getId(), ".zarray");
+        final JsonObject response = getResponseAsJson(image.getId(), LABEL_GROUP, roi1.getId(), ".zarray");
         final JsonArray shape = response.getJsonArray("shape");
         final int maskSizeX = shape.getInteger(4);
         final int maskSizeY = shape.getInteger(3);
@@ -150,7 +151,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
             for (int x = 0; x < maskSizeX; x += chunkSizeX) {
                 mockSetup();
                 final byte[] chunkZipped =
-                        getResponseAsBytes(image.getId(), "masks", roi1.getId(), 0, 0, 0, chunkIndexY, chunkIndexX);
+                        getResponseAsBytes(image.getId(), LABEL_GROUP, roi1.getId(), 0, 0, 0, chunkIndexY, chunkIndexX);
                 final byte[] chunk = uncompress(chunkZipped);
                 for (int cx = 0; cx < chunkSizeX; cx++) {
                     for (int cy = 0; cy < chunkSizeY; cy++) {
@@ -179,7 +180,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
     @Test
     public void testLabeledMaskChunks() throws DataFormatException, IOException {
         final Set<Long> seenLabels = new HashSet<>();
-        final JsonObject response = getResponseAsJson(image.getId(), "masks", DEFAULT_LABEL_NAME, ".zarray");
+        final JsonObject response = getResponseAsJson(image.getId(), LABEL_GROUP, DEFAULT_LABEL_NAME, ".zarray");
         final JsonArray shape = response.getJsonArray("shape");
         final int maskSizeX = shape.getInteger(4);
         final int maskSizeY = shape.getInteger(3);
@@ -193,7 +194,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
             int chunkIndexX = 0;
             for (int x = 0; x < maskSizeX; x += chunkSizeX) {
                 mockSetup();
-                final byte[] chunkZipped = getResponseAsBytes(image.getId(), "masks", DEFAULT_LABEL_NAME, 0, 0, 0, chunkIndexY, chunkIndexX);
+                final byte[] chunkZipped = getResponseAsBytes(image.getId(), LABEL_GROUP, DEFAULT_LABEL_NAME, 0, 0, 0, chunkIndexY, chunkIndexX);
                 final ByteBuffer chunk = ByteBuffer.wrap(uncompress(chunkZipped));
                 for (int cx = 0; cx < chunkSizeX; cx++) {
                     for (int cy = 0; cy < chunkSizeY; cy++) {

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrBinaryMaskTest.java
@@ -20,6 +20,7 @@
 package org.openmicroscopy.ms.zarr;
 
 import org.openmicroscopy.ms.zarr.mask.ImageMask;
+import static org.openmicroscopy.ms.zarr.RequestHandlerForImage.DEFAULT_LABEL_NAME;
 
 import ome.model.core.Image;
 import ome.model.core.Pixels;
@@ -178,7 +179,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
     @Test
     public void testLabeledMaskChunks() throws DataFormatException, IOException {
         final Set<Long> seenLabels = new HashSet<>();
-        final JsonObject response = getResponseAsJson(image.getId(), "masks", "labeled", ".zarray");
+        final JsonObject response = getResponseAsJson(image.getId(), "masks", DEFAULT_LABEL_NAME, ".zarray");
         final JsonArray shape = response.getJsonArray("shape");
         final int maskSizeX = shape.getInteger(4);
         final int maskSizeY = shape.getInteger(3);
@@ -192,7 +193,7 @@ public class ZarrBinaryMaskTest extends ZarrEndpointsTestBase {
             int chunkIndexX = 0;
             for (int x = 0; x < maskSizeX; x += chunkSizeX) {
                 mockSetup();
-                final byte[] chunkZipped = getResponseAsBytes(image.getId(), "masks", "labeled", 0, 0, 0, chunkIndexY, chunkIndexX);
+                final byte[] chunkZipped = getResponseAsBytes(image.getId(), "masks", DEFAULT_LABEL_NAME, 0, 0, 0, chunkIndexY, chunkIndexX);
                 final ByteBuffer chunk = ByteBuffer.wrap(uncompress(chunkZipped));
                 for (int cx = 0; cx < chunkSizeX; cx++) {
                     for (int cy = 0; cy < chunkSizeY; cy++) {


### PR DESCRIPTION
see: https://github.com/ome/omero-ms-zarr/issues/59

Also renames the single produced array to `0/` to match omero-cli-zarr