### PR TITLE
Mask color array

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -132,14 +132,16 @@ Unlisted groups MAY be masks.
 
 The `color` key defines an integer image that is "labeled", i.e. every unique value in the image
 represents a unique, non-overlapping object within the image. The value associated with
-the `color` key is another JSON object in which the key is the pixel value of the image and
-the value is an RGBA color (4 byte, `0-255` per channel) for representing the object:
+the `color` key is a JSON array in which the index is the pixel value of the image and
+the value is an RGBA color (4 byte, `0-255` per channel) for representing the object, or `null` if no color is set:
 
 ```
 {
-  "color": {
-    "1": 8388736,
+  "color": [
+    null,
+    8388736,
     ...
+  ]
 ```
 ### "image"
 

--- a/spec.md
+++ b/spec.md
@@ -130,7 +130,7 @@ Unlisted groups MAY be masks.
 
 ### "color"
 
-The `color` key defines an image that is "labeled", i.e. every unique value in the image
+The `color` key defines an integer image that is "labeled", i.e. every unique value in the image
 represents a unique, non-overlapping object within the image. The value associated with
 the `color` key is another JSON object in which the key is the pixel value of the image and
 the value is an RGBA color (4 byte, `0-255` per channel) for representing the object:

--- a/spec.md
+++ b/spec.md
@@ -130,7 +130,7 @@ Unlisted groups MAY be masks.
 
 ### "color"
 
-The `color` key defines an integer image that is "labeled", i.e. every unique value in the image
+The `color` key defines an integer image that is "labeled", i.e. every unique non-negative value in the image
 represents a unique, non-overlapping object within the image. The value associated with
 the `color` key is a JSON array in which the index is the pixel value of the image and
 the value is an RGBA color (4 byte, `0-255` per channel) for representing the object, or `null` if no color is set:


### PR DESCRIPTION
See https://github.com/ome/omero-ms-zarr/issues/62
Converts the label-color dict to an array or colours.

Also require the labels to be integers

See also an alternative in https://github.com/ome/omero-ms-zarr/pull/68