### PR TITLE
HCS specification

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -248,6 +248,8 @@ above).
 For high-content screening datasets, the plate layout can be found under the custom attributes of the plate group under the `plate` key.
 
 <dl>
+  <dt><strong>name</strong></dt>
+  <dd>A string defining the name of the plate.</dd>
   <dt><strong>plateAcquisitions</strong></dt>
   <dd>A list of JSON objects defining the acquisitions for a given plate.
       Each acquisition object MUST contain a `path` key identifying the path 
@@ -274,6 +276,7 @@ For example the following JSON object encodes a plate with one acquisition and
 ```json
 "plate":
   {
+    "name": "test",
     "rows": 2,
     "columns": 3,
     "row_names": ["A", "B"],

--- a/spec.md
+++ b/spec.md
@@ -11,6 +11,11 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## On-disk (or in-cloud) layout
 
+### Images
+
+The following layout describes the expected Zarr hierarchy for images with
+multiple levels of resolutions and optionally associated labels.
+
 ```
 
 .                             # Root folder, potentially in S3,
@@ -55,7 +60,62 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
                 ├── 0         # Each multiscale level is stored as a separate Zarr array, as above, but only integer values
                 │   ...       # are supported.
                 └── n
+```
 
+### High-content screening
+
+The following layout should describe the hierarchy for a high-content screening
+dataset. There are exactly four levels of hierarchies above the images:
+
+- the top-level group defines the plate, it MUST implement the plate
+  specification defined below
+- the second group defines all acquisitions performed on a single plate. If 
+  only one acquisition was performed, a single group must be used.
+- the third group defines all the well rows available for an acquisition
+- the fourth group defines all the well columns available for a given well row
+- the fifth group defined all the individual fields of views for a given well.
+  The fields of views are images, SHOULD implement the "multiscales"
+  specification, MAY implement the "omero" specification and MAY contain 
+  labels.
+
+```
+.                                # Root folder, potentially in S3,
+│
+├── 123.zarr                     # One image (id=123) converted to Zarr.
+│
+└── 5966.zarr                     # One plate (id=5966) converted to Zarr
+    ├── .zgroup
+    ├── .zattrs                   # Implements "plate" specification
+    │
+    ├── 2020-10-10                # First acquisition 
+    │   │
+    │   ├── .zgroup
+    │   ├── .zattrs
+    │   │
+    │   ├── A                     # First row of acquisition 2020-10-10
+    │   │   ├── .zgroup
+    │   │   ├── .zattrs
+    │   │   │
+    │   │   ├── 1                 # First column of row A
+    │   │   │   ├── .zgroup
+    │   │   │   ├── .zattrs
+    │   │   │   │
+    │   │   │   ├── Field_1       # First field of view of well A1
+    │   │   │   │   │
+    │   │   │   │   ├── .zgroup
+    │   │   │   │   ├── .zattrs   # Implements "multiscales", "omero"
+    │   │   │   │   ├── 0
+    │   │   │   │   │   ...       # Resolution levels
+    │   │   │   │   ├── n
+    │   │   │   │   └── labels
+    │   │   │   ├── ...           # Fields of view
+    │   │   │   └── Field_m
+    │   │   ├── ...               # Columns
+    │   │   └── 12
+    │   ├── ...                   # Rows
+    │   └── H
+    ├── ...                       # Acquisitions
+    └── l
 
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -5,6 +5,10 @@ scripts provided by this repository will support one or more versions of this
 file, but they should all be considered internal investigations, not intended
 for public re-use.
 
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 ## On-disk (or in-cloud) layout
 
 ```

--- a/spec.md
+++ b/spec.md
@@ -243,9 +243,85 @@ above).
 ]
 ```
 
+### "plate" metadata
+
+For high-content screening datasets, the plate layout can be found under the custom attributes of the plate group under the `plate` key.
+
+plateAcquisitions
+  A list of JSON objects defining the acquisitions for a given plate.
+  Each acquisition object MUST contain a `path` key identifying the path to the
+  acquisition group.
+
+rows
+  An integer defining the number of rows i.e. the first dimension of
+  a two-dimensional array of wells.
+
+row_names
+  A list of strings defining the names of the rows
+
+rows
+  An integer defining the number of columns i.e. the first dimension of
+  a two-dimensional array of wells.
+
+column_names
+  A list of strings defining the names of the columns
+
+images
+  A list of JSON objects defining the images (or well samples) containing in
+  the plate.
+  Each image object MUST contain a `path` key identifying the path to the
+  individual image.
+  
+
+For example the following JSON object encodes a plate with one acquisition and
+6 wells containing up to two fields of view each.
+
+```json
+"plate":
+  {
+    "rows": 2,
+    "columns": 3,
+    "row_names": ["A", "B"],
+    "column_names": ["1", "2", "3"],
+    "plateAcquisitions": [
+        {"path": "2020-10-10"}
+    ],
+    "images": [
+        {
+            "path": "2020-10-10/A/1/Field_1"
+        },
+        {
+            "path": "2020-10-10/A/1/Field_2"
+        },
+        {
+            "path": "2020-10-10/A/2/Field_1"
+        },
+        {
+            "path": "2020-10-10/A/2/Field_2"
+        },
+        },
+        {
+            "path": "2020-10-10/A/3/Field_1"
+        },
+        {
+            "path": "2020-10-10/B/1/Field_1"
+        },
+        {
+            "path": "2020-10-10/B/2/Field_1"
+        },
+        {
+            "path": "2020-10-10/B/3/Field_1"
+        }
+    ]
+  }
+```
+
+
+
 
 | Revision   | Date         | Description                                |
 | ---------- | ------------ | ------------------------------------------ |
+| 0.1.3-dev5 | TBD.         | Add the HCS specification                  |
 | 0.1.3-dev4 | 2020-09-14   | Add the image-label object                 |
 | 0.1.3-dev3 | 2020-09-01   | Convert labels to multiscales              |
 | 0.1.3-dev2 | 2020-08-18   | Rename masks as labels                     |

--- a/spec.md
+++ b/spec.md
@@ -64,7 +64,7 @@ multiple levels of resolutions and optionally associated labels.
 
 ### High-content screening
 
-The following layout should describe the hierarchy for a high-content screening
+The following layout describes the hierarchy for a high-content screening
 dataset. There are exactly four levels of hierarchies above the images:
 
 - the top-level group defines a single plate and MUST implement the plate

--- a/spec.md
+++ b/spec.md
@@ -294,7 +294,6 @@ For example the following JSON object encodes a plate with one acquisition and
         {
             "path": "2020-10-10/A/2/Field_2"
         },
-        },
         {
             "path": "2020-10-10/A/3/Field_1"
         },

--- a/spec.md
+++ b/spec.md
@@ -247,31 +247,26 @@ above).
 
 For high-content screening datasets, the plate layout can be found under the custom attributes of the plate group under the `plate` key.
 
-plateAcquisitions
-  A list of JSON objects defining the acquisitions for a given plate.
-  Each acquisition object MUST contain a `path` key identifying the path to the
-  acquisition group.
-
-rows
-  An integer defining the number of rows i.e. the first dimension of
-  a two-dimensional array of wells.
-
-row_names
-  A list of strings defining the names of the rows
-
-rows
-  An integer defining the number of columns i.e. the first dimension of
-  a two-dimensional array of wells.
-
-column_names
-  A list of strings defining the names of the columns
-
-images
-  A list of JSON objects defining the images (or well samples) containing in
-  the plate.
-  Each image object MUST contain a `path` key identifying the path to the
-  individual image.
-  
+<dl>
+  <dt><strong>plateAcquisitions</strong></dt>
+  <dd>A list of JSON objects defining the acquisitions for a given plate.
+      Each acquisition object MUST contain a `path` key identifying the path 
+      to the acquisition group.</dd>
+  <dt><strong>rows</strong></dt>
+  <dd>An integer defining the number of rows i.e. the first dimension of
+      a two-dimensional array of wells.</dd>
+  <dt><strong>row_names</strong></dt>
+  <dd>A list of strings defining the names of the rows</dd>
+  <dt><strong>rows</strong></dt>
+  <dd>An integer defining the number of columns i.e. the first dimension of
+      a two-dimensional array of wells.</dd>
+  <dt><strong>column_names</strong></dt>
+  <dd>A list of strings defining the names of the columns</dd>
+  <dt><strong>images</strong></dt>
+  <dd>A list of JSON objects defining the images (or well samples) containing      in the plate.
+      Each image object MUST contain a `path` key identifying the path to the
+      individual image.</dd>
+</dl>
 
 For example the following JSON object encodes a plate with one acquisition and
 6 wells containing up to two fields of view each.

--- a/spec.md
+++ b/spec.md
@@ -67,12 +67,16 @@ multiple levels of resolutions and optionally associated labels.
 The following layout should describe the hierarchy for a high-content screening
 dataset. There are exactly four levels of hierarchies above the images:
 
-- the top-level group defines the plate, it MUST implement the plate
+- the top-level group defines a single plate and MUST implement the plate
   specification defined below
-- the second group defines all acquisitions performed on a single plate. If 
+- the second group defines all acquisitions performed on the plate. If 
   only one acquisition was performed, a single group must be used.
-- the third group defines all the well rows available for an acquisition
-- the fourth group defines all the well columns available for a given well row
+- the third group defines all the rows available for an acquisition. The group
+  name must match the name of one of the row objects defined in the plate 
+  metadata.
+- the fourth group defines all the wells available for a given row. The group
+  name must match the name of one of the columd objects defined in the plate 
+  metadata. The well group MUST implement the well specification defined below
 - the fifth group defined all the individual fields of views for a given well.
   The fields of views are images, SHOULD implement the "multiscales"
   specification, MAY implement the "omero" specification and MAY contain 
@@ -98,9 +102,9 @@ dataset. There are exactly four levels of hierarchies above the images:
     │   │   │
     │   │   ├── 1                 # First column of row A
     │   │   │   ├── .zgroup
-    │   │   │   ├── .zattrs
+    │   │   │   ├── .zattrs       # Implements "well" specification
     │   │   │   │
-    │   │   │   ├── Field_1       # First field of view of well A1
+    │   │   │   ├── 0       # First field of view of well A1
     │   │   │   │   │
     │   │   │   │   ├── .zgroup
     │   │   │   │   ├── .zattrs   # Implements "multiscales", "omero"
@@ -109,7 +113,7 @@ dataset. There are exactly four levels of hierarchies above the images:
     │   │   │   │   ├── n
     │   │   │   │   └── labels
     │   │   │   ├── ...           # Fields of view
-    │   │   │   └── Field_m
+    │   │   │   └── m
     │   │   ├── ...               # Columns
     │   │   └── 12
     │   ├── ...                   # Rows
@@ -250,70 +254,91 @@ For high-content screening datasets, the plate layout can be found under the cus
 <dl>
   <dt><strong>name</strong></dt>
   <dd>A string defining the name of the plate.</dd>
-  <dt><strong>plateAcquisitions</strong></dt>
+  <dt><strong>acquisitions</strong></dt>
   <dd>A list of JSON objects defining the acquisitions for a given plate.
       Each acquisition object MUST contain a `path` key identifying the path 
-      to the acquisition group.</dd>
+      to the acquisition subgroup.</dd>
   <dt><strong>rows</strong></dt>
-  <dd>An integer defining the number of rows i.e. the first dimension of
-      a two-dimensional array of wells.</dd>
-  <dt><strong>row_names</strong></dt>
-  <dd>A list of strings defining the names of the rows</dd>
-  <dt><strong>rows</strong></dt>
-  <dd>An integer defining the number of columns i.e. the first dimension of
-      a two-dimensional array of wells.</dd>
-  <dt><strong>column_names</strong></dt>
-  <dd>A list of strings defining the names of the columns</dd>
-  <dt><strong>images</strong></dt>
-  <dd>A list of JSON objects defining the images (or well samples) containing      in the plate.
-      Each image object MUST contain a `path` key identifying the path to the
-      individual image.</dd>
+  <dd>A list of JSON defining the rows of the plate. Each row object defines
+      the properties of the row at the index of the object in the list. If
+      not empty, it MUST contain a `name` key specifying the row name.</dd>
+  <dt><strong>columns</strong></dt>
+  <dd>A list of JSON defining the columns of the plate. Each column object
+      defines the properties of the column at the index of the object in the
+      list. If not empty, it MUST contain a `name` key specifying the column
+      name.</dd>
+  <dt><strong>field_count</strong></dt>
+  <dd>An integer defining the maximum number of fields per view across all
+      wells.</dd>
+  <dt><strong>wells</strong></dt>
+  <dd>A list of JSON objects defining the wells of the plate. Each well object 
+      MUST contain a `path` key identifying the path to the well subgroup.</dd>
 </dl>
 
-For example the following JSON object encodes a plate with one acquisition and
-6 wells containing up to two fields of view each.
+For example the following JSON object defines a plate with one acquisition and
+6 wells (2 rows and 3 columns), containing up to three fields of view each.
 
 ```json
-"plate":
-  {
+"plate": {
+    "acquisitions": [{"path": "0"}],
+    "columns": [{"name": "1" }, {"name": "2" }, {"name": "3" }],
+    "field_count": 3,
     "name": "test",
-    "rows": 2,
-    "columns": 3,
-    "row_names": ["A", "B"],
-    "column_names": ["1", "2", "3"],
-    "plateAcquisitions": [
-        {"path": "2020-10-10"}
-    ],
-    "images": [
+    "rows": [{"name": "A" }, {"name": "B" }],
+    "wells": [
         {
-            "path": "2020-10-10/A/1/Field_1"
+            "path": "2020-10-10/A/1"
         },
         {
-            "path": "2020-10-10/A/1/Field_2"
+            "path": "2020-10-10/A/2"
         },
         {
-            "path": "2020-10-10/A/2/Field_1"
+            "path": "2020-10-10/A/3"
         },
         {
-            "path": "2020-10-10/A/2/Field_2"
+            "path": "2020-10-10/B/1"
         },
         {
-            "path": "2020-10-10/A/3/Field_1"
+            "path": "2020-10-10/B/2"
         },
         {
-            "path": "2020-10-10/B/1/Field_1"
-        },
-        {
-            "path": "2020-10-10/B/2/Field_1"
-        },
-        {
-            "path": "2020-10-10/B/3/Field_1"
+            "path": "2020-10-10/B/3"
         }
     ]
   }
 ```
 
+### "well" metadata
 
+For high-content screening datasets, the metadata about all fields of views
+under a given  well can be found under the "well" key in the attributes of the
+well group.
+
+<dl>
+  <dt><strong>images</strong></dt>
+  <dd>A list of JSON objects defining the fields of views for a given well.
+      Each object MUST contain a `path` key identifying the path to the
+      field of view.</dd>
+</dl>
+
+For example the following JSON object defines a well with three fields of
+views:
+
+```json
+"well": {
+    "images": [
+        {
+            "path": "0"
+        },
+        {
+            "path": "1"
+        },
+        {
+            "path": "2"
+        },
+    ]
+  }
+```
 
 
 | Revision   | Date         | Description                                |


### PR DESCRIPTION
Closes #73. Closes https://github.com/ome/omero-ms-zarr/issues/76 

This PR captures the successive iterations for the first draft of the HCS specification 

## 2020-10-29 

The first set of changes capture the HCS Zarr layout which which was demonstrated as part of the [2020-10-29 community call](https://forum.image.sc/t/upcoming-calls-on-next-gen-bioimaging-data-tools-starting-oct-29/43489).

Specification changes match the layout described in https://github.com/ome/omero-ms-zarr/issues/73#issuecomment-717206122 and include:

- the addition of the standard RFC2119 block
- the addition of the hierarchy description
- the addition of the plate metadata

Implementations of the 2020-10-29 version of the HCS specification include:

- [omero-cli-zarr 0.0.5](https://pypi.org/project/omero-cli-zarr/0.0.5/)
- ome-zarr TBD (including https://github.com/ome/ome-zarr-py/pull/57)

Datasets created according to the 2020-10-29 version of the HCS specification on the https://s3.embassy.ebi.ac.uk endpoint URL

- s3://idr/share/community-call-2020-10-29/idr0002-heriche-condensation/plate1_1_013/422.zarr - a 96 wells plate with timelapse images
- s3://idr/share/community-call-2020-10-29/idr0002-heriche-condensation/plate1_1_013/422_no_T.zarr - a derived form of the above containing only the first timepoint of each field of view
- s3://idr/share/community-call-2020-10-29/idr0033-rohban-pathways/41744_illum_corrected/5966.zarr - a 384 wells plate with 9 fields of views per well containing 5-channel images
- s3://idr/share/community-call-2020-10-29/idr0004-thorpe-rad52/1751.zarr - a 69 wells sparse plate with multi-Z images

## 2020-11-09

Following, the 2020-10-29 community call, a few changes were made 

- a new `name` field was added to the plate metadata (89a64fe )
- the HCS layout was reviewed including the addition of a `well` specification as described in https://github.com/ome/omero-ms-zarr/issues/76 
 (9713875  )


Implementations of the 2020-11-09 version of the HCS specification include:
- omero-cli-zarr TBD
- ome-zarr TBD

Datasets created according to the 2020-11-29 version of the HCS specification:
- TBD