### PR TITLE
0.2: use nested folders by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gradle
+.omero
+bin/
+build/
+gradle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM library/gradle:6.3.0-jre14 as build
 
 WORKDIR /omero-ms-zarr
 COPY LICENSE README.md build.gradle settings.gradle /omero-ms-zarr/
+RUN gradle build --no-daemon || return 0 # Cache dependencies
 COPY src /omero-ms-zarr/src/
-RUN gradle build -x test
+RUN gradle build --no-daemon -x test -x javadoc
 
 RUN cd build/distributions && \
     unzip omero-ms-zarr-shadow-*.zip && \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In addition to your usual OMERO.server configuration, the microservice's
 : zlib compression level for chunks, default 6
 
 `omero.ms.zarr.folder.layout`
-: for directory listings, default `flattened` chunks, can be `nested`; `none` disables directory listings
+: for directory listings, default `nested` chunks, can be `flattened`; `none` disables directory listings
 
 `omero.ms.zarr.mask.split.enable`
 : if masks split by ROI should be offered; default is `false`, can be set to `true`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3"
+
+services:
+
+  database:
+    image: "postgres:11"
+    environment:
+      POSTGRES_USER: omero
+      POSTGRES_DB: omero
+      POSTGRES_PASSWORD: omero
+    networks:
+      - omero
+    volumes:
+      - "database:/var/lib/postgresql/data"
+    command:
+      - "postgres"
+      - "-N"
+      - "500"
+
+  omeroserver:
+    image: "openmicroscopy/omero-server:5.6"
+    environment:
+      CONFIG_omero_db_host: database
+      CONFIG_omero_db_user: omero
+      CONFIG_omero_db_pass: omero
+      CONFIG_omero_db_name: omero
+      ROOTPASS: omero
+    networks:
+      - omero
+    ports:
+      - "4063:4063"
+      - "4064:4064"
+    volumes:
+      - "omero:/OMERO"
+
+  omeroweb:
+    image: "openmicroscopy/omero-web-standalone:5.6"
+    environment:
+      OMEROHOST: omeroserver
+    networks:
+      - omero
+    ports:
+      - "4080:4080"
+
+  zarr:
+    build: "."
+    environment:
+      CONFIG_omero_db_host: database
+      CONFIG_omero_db_user: omero
+      CONFIG_omero_db_pass: omero
+      CONFIG_omero_db_name: omero
+
+    volumes:
+      - "omero:/OMERO:ro"
+    networks:
+      - omero
+    ports:
+      - "8080:8080"
+    restart: on-failure
+
+networks:
+  omero:
+
+volumes:
+  database:
+  omero:

--- a/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/Configuration.java
@@ -65,7 +65,7 @@ public class Configuration {
     private List<Character> chunkSizeAdjust = ImmutableList.of('X', 'Y', 'Z');
     private int chunkSizeMin = 0x100000;
     private int zlibLevel = 6;
-    private Boolean foldersNested = false;
+    private Boolean foldersNested = true;
     private String netPath = getRegexForNetPath("/image/" + PLACEHOLDER_IMAGE_ID + ".zarr/");
     private int netPort = 8080;
     private boolean maskSplitEnable = false;

--- a/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
+++ b/src/main/java/org/openmicroscopy/ms/zarr/RequestHandlerForImage.java
@@ -1121,7 +1121,7 @@ public class RequestHandlerForImage implements HttpHandler {
         }
         final Map<String, Object> omero = buildOmeroMetadata(pixels);
         final Map<String, Object> multiscale = new HashMap<>();
-        multiscale.put("version", "0.1");
+        multiscale.put("version", "0.2");
         multiscale.put("name", "default");
         multiscale.put("datasets", datasets);
         final JsonArray multiscales = new JsonArray();


### PR DESCRIPTION
Swaps the default of `omero.ms.zarr.folder.layout` property and changes the version to `0.2`.