### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v2.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 repositories {
     maven {
-        url = 'http://artifacts.openmicroscopy.org/artifactory/maven'
+        url = 'https://artifacts.openmicroscopy.org/artifactory/maven'
     }
     mavenCentral()
 }

--- a/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
+++ b/src/test/java/org/openmicroscopy/ms/zarr/ZarrMetadataTest.java
@@ -102,7 +102,7 @@ public class ZarrMetadataTest extends ZarrEndpointsImageTestBase {
             paths.add(path);
         }
         Assertions.assertEquals(pixelBuffer.getResolutionLevels(), paths.size());
-        Assertions.assertEquals("0.1", multiscale.getString("version"));
+        Assertions.assertEquals("0.2", multiscale.getString("version"));
         /* OMERO extras */
         final JsonObject omero = response.getJsonObject("omero");
         assertNoExtraKeys(omero, "id", "name", "channels", "rdefs");


### PR DESCRIPTION
Problem noticed while working on ``repository dispatch``.
Gradle 7 is used by GitHub action to check the project

Suggestion for another PR or I could push a commit to that PR
bump the version of gradle we use in the GitHub action to 6.6.1